### PR TITLE
1/5 signing session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ deploy-katana:
 
 test-session: generate_artifacts
 	rm -rf ./account_sdk/log
-	cargo test --manifest-path account_sdk/Cargo.toml session
+	cargo test --manifest-path account_sdk/Cargo.toml session -- --nocapture

--- a/account_sdk/Cargo.toml
+++ b/account_sdk/Cargo.toml
@@ -31,3 +31,4 @@ webauthn-rs-proto = "0.4.9"
 base64 = "0.21.5"
 sha2 = "0.10.8"
 cainome = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.1.0", features = ["abigen-rs"] }
+starknet-crypto = "0.6.1"

--- a/account_sdk/src/lib.rs
+++ b/account_sdk/src/lib.rs
@@ -4,7 +4,7 @@ pub mod webauthn_signer;
 
 pub mod abigen;
 pub mod felt_ser;
-mod session_token;
+pub mod session_token;
 
 #[cfg(test)]
 pub mod tests;

--- a/account_sdk/src/session_token/account.rs
+++ b/account_sdk/src/session_token/account.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use cainome::cairo_serde::CairoSerde;
+use cainome::cairo_serde::{CairoSerde, ContractAddress};
 use starknet::{
     accounts::{
         Account, Call as StarknetCall, ConnectedAccount, Declaration, Execution, ExecutionEncoder,
@@ -14,7 +14,8 @@ use starknet::{
 };
 use std::{sync::Arc, vec};
 
-use crate::abigen::account::SessionSignature;
+use super::session::SessionError;
+use crate::abigen::account::{Call, SessionSignature};
 use crate::session_token::Session;
 
 impl<P, S> ExecutionEncoder for SessionAccount<P, S>
@@ -44,6 +45,8 @@ pub enum SignError<S, P> {
     Signer(S),
     #[error(transparent)]
     SignersPubkey(P),
+    #[error(transparent)]
+    Session(SessionError),
 }
 
 pub struct SessionAccount<P, S>
@@ -110,6 +113,9 @@ where
         execution: &RawExecution,
         query_only: bool,
     ) -> Result<Vec<FieldElement>, Self::SignError> {
+        // Call structures are private, but printable, so can be parsed
+        let calls = parse_calls(execution);
+
         let tx_hash = execution.transaction_hash(self.chain_id, self.address, query_only, self);
         let signature = self
             .signer
@@ -117,7 +123,10 @@ where
             .await
             .map_err(SignError::Signer)?;
 
-        let signature = self.session.signature(signature, 0);
+        let signature = self
+            .session
+            .signature(signature, calls)
+            .map_err(SignError::Session)?;
 
         Ok(SessionSignature::cairo_serialize(&signature))
     }
@@ -153,6 +162,27 @@ where
     fn declare_legacy(&self, contract_class: Arc<LegacyContractClass>) -> LegacyDeclaration<Self> {
         LegacyDeclaration::new(contract_class, self)
     }
+}
+
+pub fn parse_calls(execution: &RawExecution) -> Vec<Call> {
+    let tx_printed = format!("{:?}", execution);
+    let mut individual_calls = tx_printed.split("Call { to: FieldElement { inner: ");
+    individual_calls.next(); // First one is not a call
+
+    individual_calls
+        .map(|call| {
+            let mut call = call.split(" }, selector: FieldElement { inner: ");
+            let to = call.next().unwrap();
+            let selector = call.next().unwrap();
+            let selector = selector.split(" }").next().unwrap();
+
+            Call {
+                to: ContractAddress::from(FieldElement::from_hex_be(to).unwrap()),
+                selector: FieldElement::from_hex_be(selector).unwrap(),
+                calldata: vec![],
+            }
+        })
+        .collect()
 }
 
 impl<P, S> ConnectedAccount for SessionAccount<P, S>

--- a/account_sdk/src/session_token/account.rs
+++ b/account_sdk/src/session_token/account.rs
@@ -79,7 +79,11 @@ where
         }
     }
 
-    pub fn session(&mut self) -> &mut Session {
+    pub fn session(&self) -> &Session {
+        &self.session
+    }
+
+    pub fn session_mut(&mut self) -> &mut Session {
         &mut self.session
     }
 }

--- a/account_sdk/src/session_token/hash.rs
+++ b/account_sdk/src/session_token/hash.rs
@@ -18,7 +18,7 @@ const POLICY_TYPE_HASH: FieldElement =
 
 const STARKNET_MESSAGE_FELT: FieldElement = felt!("0x537461726b4e6574204d657373616765");
 
-fn compute_session_hash(
+pub fn compute_session_hash(
     signature: SessionSignature,
     chain_id: FieldElement,
     account: FieldElement,
@@ -37,7 +37,7 @@ fn compute_session_hash(
     hasher.finalize()
 }
 
-fn compute_call_hash(call: &Call) -> FieldElement {
+pub fn compute_call_hash(call: &Call) -> FieldElement {
     let mut hasher = PoseidonHasher::new();
     hasher.update(POLICY_TYPE_HASH);
     hasher.update((call.to).into());
@@ -45,14 +45,14 @@ fn compute_call_hash(call: &Call) -> FieldElement {
     hasher.finalize()
 }
 
-fn hash_domain(chain_id: FieldElement) -> FieldElement {
+pub fn hash_domain(chain_id: FieldElement) -> FieldElement {
     let mut hasher = PoseidonHasher::new();
     hasher.update(STARKNET_DOMAIN_TYPE_HASH);
     hasher.update(chain_id);
     hasher.finalize()
 }
 
-fn hash_message(
+pub fn hash_message(
     session_key: FieldElement,
     session_expires: FieldElement,
     root: FieldElement,

--- a/account_sdk/src/session_token/hash.rs
+++ b/account_sdk/src/session_token/hash.rs
@@ -78,6 +78,24 @@ pub fn calculate_merkle_proof(call_hashes: &Vec<FieldElement>, index: usize) -> 
     proof
 }
 
+pub fn compute_root(mut current_node: FieldElement, mut proof: Vec<FieldElement>) -> FieldElement {
+    loop {
+        if proof.is_empty() {
+            break current_node;
+        }
+
+        let proof_element = proof.remove(0);
+        // Compute the hash of the current node and the current element of the proof.
+        // We need to check if the current node is smaller than the current element of the proof.
+        // If it is, we need to swap the order of the hash.
+        current_node = if current_node < proof_element {
+            hash_two_elements(current_node, proof_element)
+        } else {
+            hash_two_elements(proof_element, current_node)
+        };
+    }
+}
+
 // based on: https://github.com/keep-starknet-strange/alexandria/blob/ecc881e2aee668332441bdfa32336e3404cf8eb1/src/merkle_tree/src/merkle_tree.cairo#L182C4-L215
 fn compute_proof(mut nodes: Vec<FieldElement>, index: usize, proof: &mut Vec<FieldElement>) {
     // Break if we have reached the top of the tree

--- a/account_sdk/src/session_token/hash.rs
+++ b/account_sdk/src/session_token/hash.rs
@@ -1,5 +1,5 @@
 use starknet::{core::types::FieldElement, macros::felt};
-use starknet_crypto::PoseidonHasher;
+use starknet_crypto::{poseidon_hash, PoseidonHasher};
 
 use crate::abigen::account::{Call, SessionSignature};
 
@@ -17,6 +17,13 @@ const POLICY_TYPE_HASH: FieldElement =
     felt!("0x2f0026e78543f036f33e26a8f5891b88c58dc1e20cbbfaf0bb53274da6fa568");
 
 const STARKNET_MESSAGE_FELT: FieldElement = felt!("0x537461726b4e6574204d657373616765");
+
+fn hash_two_elements(a: FieldElement, b: FieldElement) -> FieldElement {
+    let mut hasher = PoseidonHasher::new();
+    hasher.update(a);
+    hasher.update(b);
+    hasher.finalize()
+}
 
 pub fn compute_session_hash(
     signature: SessionSignature,
@@ -63,4 +70,101 @@ pub fn hash_message(
     hasher.update(session_expires);
     hasher.update(root);
     hasher.finalize()
+}
+
+// based on: https://github.com/keep-starknet-strange/alexandria/blob/ecc881e2aee668332441bdfa32336e3404cf8eb1/src/merkle_tree/src/merkle_tree.cairo#L182C4-L215
+pub fn compute_proof(mut nodes: Vec<FieldElement>, index: usize, proof: &mut Vec<FieldElement>) {
+    // Break if we have reached the top of the tree
+    if nodes.len() == 1 {
+        return;
+    }
+
+    // If odd number of nodes, add a null virtual leaf
+    if nodes.len() % 2 != 0 {
+        nodes.push(FieldElement::ZERO);
+    }
+
+    // Compute next level
+    let next_level = get_next_level(nodes.clone());
+
+    // Find neighbor node
+    let index_parent;
+    let mut i = 0usize;
+    loop {
+        if i == index {
+            index_parent = i / 2;
+            if i % 2 == 0 {
+                proof.push(nodes[i + 1]);
+            } else {
+                proof.push(nodes[i - 1]);
+            }
+            break;
+        }
+        i += 1;
+    }
+
+    compute_proof(next_level, index_parent, proof)
+}
+
+fn get_next_level(mut nodes: Vec<FieldElement>) -> Vec<FieldElement> {
+    let mut next_level: Vec<FieldElement> = Vec::with_capacity(nodes.len() / 2);
+    while !nodes.is_empty() {
+        let left = nodes.remove(0);
+        let right = nodes.remove(0);
+
+        let node = if left < right {
+            hash_two_elements(left, right)
+        } else {
+            hash_two_elements(right, left)
+        };
+        next_level.push(node);
+    }
+    next_level
+}
+
+// Example from https://github.com/keep-starknet-strange/alexandria/blob/ecc881e2aee668332441bdfa32336e3404cf8eb1/src/merkle_tree/src/tests/merkle_tree_test.cairo#L104-L151
+#[test]
+fn merkle_tree_poseidon_test() {
+    // [Setup] Merkle tree.
+    let root = felt!("0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47");
+    let leaf = 0x1;
+    let valid_proof = vec![
+        felt!("0x2"),
+        felt!("0x47ef3ad11ad3f8fc055281f1721acd537563ec134036bc4bd4de2af151f0832"),
+    ];
+    let leaves = vec![felt!("0x1"), felt!("0x2"), felt!("0x3")];
+
+    // // [Assert] Compute merkle root.
+    // let computed_root = compute_root(leaf, valid_proof);
+    // assert(computed_root == root, 'compute valid root failed');
+
+    // [Assert] Compute merkle proof.
+    let mut input_leaves = leaves;
+    let index = 0;
+    let mut computed_proof = vec![];
+    compute_proof(input_leaves, index, &mut computed_proof);
+    assert_eq!(computed_proof, valid_proof, "compute valid proof failed");
+
+    // // [Assert] Verify a valid proof.
+    // let result = MerkleTreeImpl::<
+    //     _, PoseidonHasherImpl
+    // >::verify(ref merkle_tree, root, leaf, valid_proof);
+    // assert(result, 'verify valid proof failed');
+
+    // // [Assert] Verify an invalid proof.
+    // let invalid_proof = array![
+    //     0x2 + 1, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc
+    // ]
+    //     .span();
+    // let result = MerkleTreeImpl::<
+    //     _, PoseidonHasherImpl
+    // >::verify(ref merkle_tree, root, leaf, invalid_proof);
+    // assert(!result, 'verify invalid proof failed');
+
+    // // [Assert] Verify a valid proof with an invalid leaf.
+    // let invalid_leaf = 0x1 + 1;
+    // let result = MerkleTreeImpl::<
+    //     _, PoseidonHasherImpl
+    // >::verify(ref merkle_tree, root, invalid_leaf, valid_proof);
+    // assert(!result, 'wrong result');
 }

--- a/account_sdk/src/session_token/hash.rs
+++ b/account_sdk/src/session_token/hash.rs
@@ -1,0 +1,66 @@
+use starknet::{core::types::FieldElement, macros::felt};
+use starknet_crypto::PoseidonHasher;
+
+use crate::abigen::account::{Call, SessionSignature};
+
+// needs to behave anologously to https://github.com/keep-starknet-strange/alexandria,
+// which uses starknets hash, reimplemented here https://github.com/starkware-libs/cairo-lang/blob/12ca9e91bbdc8a423c63280949c7e34382792067/src/starkware/cairo/common/poseidon_hash.py#L46
+
+// H('StarkNetDomain(chainId:felt)')
+const STARKNET_DOMAIN_TYPE_HASH: FieldElement =
+    felt!("0x13cda234a04d66db62c06b8e3ad5f91bd0c67286c2c7519a826cf49da6ba478");
+// H('Session(key:felt,expires:felt,root:merkletree)')
+const SESSION_TYPE_HASH: FieldElement =
+    felt!("0x1aa0e1c56b45cf06a54534fa1707c54e520b842feb21d03b7deddb6f1e340c");
+// H(Policy(contractAddress:felt,selector:selector))
+const POLICY_TYPE_HASH: FieldElement =
+    felt!("0x2f0026e78543f036f33e26a8f5891b88c58dc1e20cbbfaf0bb53274da6fa568");
+
+const STARKNET_MESSAGE_FELT: FieldElement = felt!("0x537461726b4e6574204d657373616765");
+
+fn compute_session_hash(
+    signature: SessionSignature,
+    chain_id: FieldElement,
+    account: FieldElement,
+) -> FieldElement {
+    let domain_hash = hash_domain(chain_id);
+    let message_hash = hash_message(
+        signature.session_key,
+        signature.session_expires.into(),
+        signature.root,
+    );
+    let mut hasher = PoseidonHasher::new();
+    hasher.update(STARKNET_MESSAGE_FELT);
+    hasher.update(domain_hash);
+    hasher.update(account.into());
+    hasher.update(message_hash);
+    hasher.finalize()
+}
+
+fn compute_call_hash(call: &Call) -> FieldElement {
+    let mut hasher = PoseidonHasher::new();
+    hasher.update(POLICY_TYPE_HASH);
+    hasher.update((call.to).into());
+    hasher.update(call.selector);
+    hasher.finalize()
+}
+
+fn hash_domain(chain_id: FieldElement) -> FieldElement {
+    let mut hasher = PoseidonHasher::new();
+    hasher.update(STARKNET_DOMAIN_TYPE_HASH);
+    hasher.update(chain_id);
+    hasher.finalize()
+}
+
+fn hash_message(
+    session_key: FieldElement,
+    session_expires: FieldElement,
+    root: FieldElement,
+) -> FieldElement {
+    let mut hasher = PoseidonHasher::new();
+    hasher.update(SESSION_TYPE_HASH);
+    hasher.update(session_key);
+    hasher.update(session_expires);
+    hasher.update(root);
+    hasher.finalize()
+}

--- a/account_sdk/src/session_token/hash.rs
+++ b/account_sdk/src/session_token/hash.rs
@@ -72,8 +72,14 @@ pub fn hash_message(
     hasher.finalize()
 }
 
+pub fn calculate_merkle_proof(call_hashes: &Vec<FieldElement>, index: usize) -> Vec<FieldElement> {
+    let mut proof = vec![];
+    compute_proof(call_hashes.clone(), index, &mut proof);
+    proof
+}
+
 // based on: https://github.com/keep-starknet-strange/alexandria/blob/ecc881e2aee668332441bdfa32336e3404cf8eb1/src/merkle_tree/src/merkle_tree.cairo#L182C4-L215
-pub fn compute_proof(mut nodes: Vec<FieldElement>, index: usize, proof: &mut Vec<FieldElement>) {
+fn compute_proof(mut nodes: Vec<FieldElement>, index: usize, proof: &mut Vec<FieldElement>) {
     // Break if we have reached the top of the tree
     if nodes.len() == 1 {
         return;

--- a/account_sdk/src/session_token/mod.rs
+++ b/account_sdk/src/session_token/mod.rs
@@ -125,7 +125,7 @@ mod tests {
         // Letting the session revoke itself
         account.revoke_session(&session_token).send().await.unwrap();
 
-        sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(200)).await;
 
         // The session should not be able to sign calls anymore
         let revoked_token = vec![FieldElement::from(0x2137u32), FieldElement::from(0x2137u32)];

--- a/account_sdk/src/session_token/mod.rs
+++ b/account_sdk/src/session_token/mod.rs
@@ -82,11 +82,8 @@ mod tests {
         assert_eq!(sesion_account.address(), master_account.address());
 
         // The session is used to sign a call
-        account
-            .revoke_session(&FieldElement::from(0x2137u32))
-            .send()
-            .await
-            .unwrap();
+        let revoked_token = vec![FieldElement::from(0x2137u32), FieldElement::from(0x2137u32)];
+        account.revoke_session(&revoked_token).send().await.unwrap();
     }
 
     #[tokio::test]
@@ -105,10 +102,8 @@ mod tests {
 
         // Calling the method not included in permitted
         let account = CartridgeAccount::new(session_account.address(), &session_account);
-        let result = account
-            .revoke_session(&FieldElement::from(0x2137u32))
-            .send()
-            .await;
+        let revoked_token = vec![FieldElement::from(0x2137u32), FieldElement::from(0x2137u32)];
+        let result = account.revoke_session(&revoked_token).send().await;
 
         assert!(result.is_err(), "Signature verification should fail");
     }
@@ -122,13 +117,13 @@ mod tests {
         let account = CartridgeAccount::new(session_account.address(), &session_account);
 
         // Letting the session revoke itself
-        let revoked_token = session_token[0];
-        account.revoke_session(&revoked_token).send().await.unwrap();
+        account.revoke_session(&session_token).send().await.unwrap();
 
-        sleep(Duration::from_millis(500)).await;
+        sleep(Duration::from_millis(100)).await;
 
         // The session should not be able to sign calls anymore
-        let result = account.revoke_session(&felt!("0x2137")).send().await;
+        let revoked_token = vec![FieldElement::from(0x2137u32), FieldElement::from(0x2137u32)];
+        let result = account.revoke_session(&revoked_token).send().await;
         assert!(result.is_err(), "Session should be revoked");
     }
 
@@ -159,10 +154,8 @@ mod tests {
 
         // Calling the method not included in permitted
         let account = CartridgeAccount::new(session_account.address(), &session_account);
-        let result = account
-            .revoke_session(&FieldElement::from(0x2137u32))
-            .send()
-            .await;
+        let revoked_token = vec![FieldElement::from(0x2137u32), FieldElement::from(0x2137u32)];
+        let result = account.revoke_session(&revoked_token).send().await;
 
         assert!(result.is_err(), "Signature verification should fail");
     }
@@ -213,11 +206,8 @@ mod tests {
         // Calling using the new session token
         let account = CartridgeAccount::new(session_account.address(), &session_account);
 
-        account
-            .revoke_session(&FieldElement::from(0x2137u32))
-            .send()
-            .await
-            .unwrap();
+        let revoked_token = vec![FieldElement::from(0x2137u32), FieldElement::from(0x2137u32)];
+        account.revoke_session(&revoked_token).send().await.unwrap();
     }
 
     #[tokio::test]

--- a/account_sdk/src/session_token/mod.rs
+++ b/account_sdk/src/session_token/mod.rs
@@ -9,7 +9,7 @@ pub use sequence::CallSequence;
 pub use session::Session;
 use starknet::{core::types::FieldElement, macros::felt};
 
-pub const SIGNATURE_TYPE: FieldElement = felt!("0x53657373696f6e20546f6b656e207631"); // 'Session Token v1'
+pub const SESSION_SIGNATURE_TYPE: FieldElement = felt!("0x53657373696f6e20546f6b656e207631"); // 'Session Token v1'
 
 #[cfg(test)]
 mod tests {
@@ -19,86 +19,50 @@ mod tests {
     use starknet::{
         accounts::{Account, ConnectedAccount},
         macros::selector,
-        signers::{LocalWallet, SigningKey},
+        signers::{LocalWallet, Signer, SigningKey, VerifyingKey},
     };
     use tokio::time::sleep;
 
-    use crate::session_token::SessionAccount;
     use crate::tests::{
         deployment_test::create_account,
         runners::{KatanaRunner, TestnetRunner},
     };
     use crate::{
-        abigen::{
-            self,
-            account::{Call, CartridgeAccount},
-        },
+        abigen::account::{Call, CartridgeAccount, SessionSignature, SignatureProofs},
         session_token::test_utils::create_session_account,
     };
+    use crate::{deploy_contract::single_owner_account, session_token::SessionAccount};
 
     use super::*;
 
     #[tokio::test]
-    async fn test_session_compute_proof() {
-        let runner = KatanaRunner::load();
-        let master = create_account(&runner.prefunded_single_owner_account().await).await;
-
-        let address = master.address();
-        let account = CartridgeAccount::new(address, &master);
-
-        let cainome_address = cainome::cairo_serde::ContractAddress::from(address);
-
-        let call = abigen::account::Call {
-            to: cainome_address,
-            selector: selector!("revoke_session"),
-            calldata: vec![FieldElement::from(0x2137u32)],
-        };
-
-        let proof = account.compute_proof(&vec![call], &0).call().await.unwrap();
-
-        assert_eq!(proof, vec![]);
-    }
-
-    #[tokio::test]
-    async fn test_session_compute_root() {
-        let runner = KatanaRunner::load();
-        let master = create_account(&runner.prefunded_single_owner_account().await).await;
-
-        let address = master.address();
-        let account = CartridgeAccount::new(address, &master);
-
-        let cainome_address = ContractAddress::from(address);
-
-        let call = Call {
-            to: cainome_address,
-            selector: selector!("revoke_session"),
-            calldata: vec![FieldElement::from(0x2137u32)],
-        };
-
-        let root = account.compute_root(&call, &vec![]).call().await.unwrap();
-
-        assert_ne!(root, felt!("0x0"));
-    }
-
-    #[tokio::test]
     async fn test_session_valid() {
         let runner = KatanaRunner::load();
-        let master = create_account(&runner.prefunded_single_owner_account().await).await;
+        let (master_account, master_key) =
+            create_account(&runner.prefunded_single_owner_account().await).await;
 
         let session_key = LocalWallet::from(SigningKey::from_random());
 
-        let mut session = Session::default();
-        let cainome_address = ContractAddress::from(master.address());
+        let mut session = Session::new(session_key.get_public_key().await.unwrap(), u64::MAX);
+        let cainome_address = ContractAddress::from(master_account.address());
         let permited_calls = vec![Call {
             to: cainome_address,
             selector: selector!("revoke_session"),
             calldata: vec![FieldElement::from(0x2137u32)],
         }];
 
-        session.set_permitted_calls(permited_calls);
+        let master_cartridge_account =
+            CartridgeAccount::new(master_account.address(), &master_account);
+        let session_hash = session
+            .set_permitted_calls(permited_calls, master_cartridge_account)
+            .await
+            .unwrap();
 
-        let (chain_id, address) = (master.chain_id(), master.address());
-        let provider = *master.provider();
+        let session_token = master_key.sign(&session_hash).unwrap();
+        session.set_token(session_token);
+
+        let (chain_id, address) = (master_account.chain_id(), master_account.address());
+        let provider = *master_account.provider();
         let account = SessionAccount::new(provider, session_key, session, address, chain_id);
         let account = CartridgeAccount::new(address, &account);
 
@@ -112,39 +76,56 @@ mod tests {
     #[tokio::test]
     async fn test_session_revoked() {
         let runner = KatanaRunner::load();
-        let session_account =
-            create_session_account(&runner.prefunded_single_owner_account().await).await;
+        let prefunded_account = runner.prefunded_single_owner_account().await;
+        let (session_account, master_key) = create_session_account(&prefunded_account).await;
 
         let account = CartridgeAccount::new(session_account.address(), &session_account);
 
+        let revoked_address = session_account.address();
         account
-            .revoke_session(&FieldElement::from(0x2137u32))
+            .revoke_session(&revoked_address)
             .send()
             .await
             .unwrap();
 
         sleep(Duration::from_millis(100)).await;
 
-        let result = account
-            .revoke_session(&FieldElement::from(0x2137u32))
-            .send()
-            .await;
+        let result = account.revoke_session(&revoked_address).send().await;
 
         assert!(result.is_err(), "Session should be revoked");
     }
 
     #[tokio::test]
     async fn test_session_invalid_proof() {
-        let runner = KatanaRunner::load();
-        let mut session_account =
-            create_session_account(&runner.prefunded_single_owner_account().await).await;
+        let runner: KatanaRunner = KatanaRunner::load();
+        let prefunded_account = runner.prefunded_single_owner_account().await;
+        let (mut session_account, master_key) = create_session_account(&prefunded_account).await;
 
         let cainome_address = ContractAddress::from(session_account.address());
-        session_account.session().set_permitted_calls(vec![Call {
-            to: cainome_address,
-            selector: selector!("validate_session"),
-            calldata: vec![FieldElement::from(0x2137u32)],
-        }]);
+
+        let master_account = single_owner_account(
+            session_account.provider(),
+            master_key.clone(),
+            session_account.address(),
+        )
+        .await;
+        let master_account = CartridgeAccount::new(session_account.address(), &master_account);
+
+        let session = session_account.session();
+        let session_hash = session
+            .set_permitted_calls(
+                vec![Call {
+                    to: cainome_address,
+                    selector: selector!("validate_session"),
+                    calldata: vec![],
+                }],
+                master_account,
+            )
+            .await
+            .unwrap();
+
+        let session_token = master_key.sign(&session_hash).unwrap();
+        session.set_token(session_token);
 
         let account = CartridgeAccount::new(session_account.address(), &session_account);
 
@@ -153,38 +134,52 @@ mod tests {
             .send()
             .await;
 
-        assert!(result.is_err(), "Session should be revoked");
+        assert!(result.is_err(), "Signature verification should fail");
     }
 
     #[tokio::test]
     async fn test_session_many_allowed() {
         let runner = KatanaRunner::load();
-        let mut session_account =
-            create_session_account(&runner.prefunded_single_owner_account().await).await;
+        let prefunded_account = runner.prefunded_single_owner_account().await;
+        let (mut session_account, master_key) = create_session_account(&prefunded_account).await;
 
+        let master_account = single_owner_account(
+            session_account.provider(),
+            master_key.clone(),
+            session_account.address(),
+        )
+        .await;
+        let master_account = CartridgeAccount::new(session_account.address(), &master_account);
         let cainome_address = ContractAddress::from(session_account.address());
-        session_account.session().set_permitted_calls(vec![
-            Call {
-                to: cainome_address,
-                selector: selector!("revoke_session"),
-                calldata: vec![],
-            },
-            Call {
-                to: cainome_address,
-                selector: selector!("validate_session"),
-                calldata: vec![],
-            },
-            Call {
-                to: cainome_address,
-                selector: selector!("compute_root"),
-                calldata: vec![],
-            },
-            Call {
-                to: cainome_address,
-                selector: selector!("not_yet_defined"),
-                calldata: vec![],
-            },
-        ]);
+        session_account
+            .session()
+            .set_permitted_calls(
+                vec![
+                    Call {
+                        to: cainome_address,
+                        selector: selector!("revoke_session"),
+                        calldata: vec![],
+                    },
+                    Call {
+                        to: cainome_address,
+                        selector: selector!("validate_session"),
+                        calldata: vec![],
+                    },
+                    Call {
+                        to: cainome_address,
+                        selector: selector!("compute_root"),
+                        calldata: vec![],
+                    },
+                    Call {
+                        to: cainome_address,
+                        selector: selector!("not_yet_defined"),
+                        calldata: vec![],
+                    },
+                ],
+                master_account,
+            )
+            .await
+            .unwrap();
 
         let account = CartridgeAccount::new(session_account.address(), &session_account);
 
@@ -193,5 +188,49 @@ mod tests {
             .send()
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_session_compute_proof() {
+        let runner = KatanaRunner::load();
+        let (master_account, master_key) =
+            create_account(&runner.prefunded_single_owner_account().await).await;
+
+        let address = master_account.address();
+        let account = CartridgeAccount::new(address, &master_account);
+
+        let cainome_address = ContractAddress::from(address);
+
+        let call = Call {
+            to: cainome_address,
+            selector: selector!("revoke_session"),
+            calldata: vec![FieldElement::from(0x2137u32)],
+        };
+
+        let proof = account.compute_proof(&vec![call], &0).call().await.unwrap();
+
+        assert_eq!(proof, vec![]);
+    }
+
+    #[tokio::test]
+    async fn test_session_compute_root() {
+        let runner = KatanaRunner::load();
+        let (master_account, master_key) =
+            create_account(&runner.prefunded_single_owner_account().await).await;
+
+        let address = master_account.address();
+        let account = CartridgeAccount::new(address, &master_account);
+
+        let cainome_address = ContractAddress::from(address);
+
+        let call = Call {
+            to: cainome_address,
+            selector: selector!("revoke_session"),
+            calldata: vec![FieldElement::from(0x2137u32)],
+        };
+
+        let root = account.compute_root(&call, &vec![]).call().await.unwrap();
+
+        assert_ne!(root, felt!("0x0"));
     }
 }

--- a/account_sdk/src/session_token/mod.rs
+++ b/account_sdk/src/session_token/mod.rs
@@ -1,4 +1,5 @@
 mod account;
+mod hash;
 mod sequence;
 mod session;
 #[cfg(test)]

--- a/account_sdk/src/session_token/mod.rs
+++ b/account_sdk/src/session_token/mod.rs
@@ -45,8 +45,6 @@ mod tests {
         // Initialize a cartridge account, funding it from the prefunded account
         let prefunded_account = runner.prefunded_single_owner_account().await;
         let (master_account, master_key) = create_account(&prefunded_account).await;
-        let master_cartridge_account =
-            CartridgeAccount::new(master_account.address(), &master_account);
 
         // Creating a session, that will be used to sign calls
         let session_key = SigningKey::from_secret_scalar(FieldElement::from(2137u32));
@@ -65,7 +63,6 @@ mod tests {
         let session_hash = session
             .set_policy(
                 permitted_calls,
-                master_cartridge_account,
                 master_account.chain_id(),
                 master_account.address(),
             )
@@ -139,8 +136,6 @@ mod tests {
         // Initializing a prepared session account and master account
         let (mut session_account, master_key, master_account) =
             create_session_account(&runner).await;
-        let master_cartridge_account =
-            CartridgeAccount::new(session_account.address(), &master_account);
 
         // Setting a single allowed call, not including the one later called
         let permitted_calls = vec![Call {
@@ -154,7 +149,6 @@ mod tests {
         let session_hash = session
             .set_policy(
                 permitted_calls,
-                master_cartridge_account,
                 master_account.chain_id(),
                 master_account.address(),
             )
@@ -178,8 +172,6 @@ mod tests {
         // Initializing a prepared session account and master account
         let (mut session_account, master_key, master_account) =
             create_session_account(&runner).await;
-        let master_cartridge_account =
-            CartridgeAccount::new(session_account.address(), &master_account);
 
         // Defining multiple allowed calls
         let to = ContractAddress::from(session_account.address());
@@ -209,7 +201,6 @@ mod tests {
         let session_hash = session
             .set_policy(
                 permitted_calls,
-                master_cartridge_account,
                 master_account.chain_id(),
                 master_account.address(),
             )

--- a/account_sdk/src/session_token/session.rs
+++ b/account_sdk/src/session_token/session.rs
@@ -1,12 +1,25 @@
-use starknet::{core::types::FieldElement, macros::felt};
+use starknet::{
+    accounts::{Account, ConnectedAccount},
+    core::types::FieldElement,
+    macros::felt,
+};
 
-use crate::abigen::account::Call;
+use crate::abigen::account::{Call, CartridgeAccount};
+
+#[derive(Clone)]
+pub struct CallWithProof(pub Call, pub Vec<FieldElement>);
 
 #[derive(Clone)]
 pub struct Session {
     session_expires: u64,
+    calls: Vec<CallWithProof>,
     session_token: Vec<FieldElement>,
-    permitted_calls: Vec<Call>,
+    root: FieldElement,
+}
+
+enum SessionError {
+    NoCallsPermited,
+    ChainCallFailed,
 }
 
 impl Session {
@@ -18,13 +31,41 @@ impl Session {
         self.session_token.clone()
     }
 
-    pub fn permitted_calls(&self) -> &Vec<Call> {
-        &self.permitted_calls
+    pub fn call_with_proof(&self, position: usize) -> &CallWithProof {
+        &self.calls[position]
     }
 
-    #[cfg(test)]
-    pub fn set_permitted_calls(&mut self, calls: Vec<Call>) {
-        self.permitted_calls = calls;
+    pub async fn set_permitted_calls<A>(
+        &mut self,
+        calls: Vec<Call>,
+        account: CartridgeAccount<A>,
+    ) -> Result<(), SessionError>
+    where
+        A: Account + ConnectedAccount + Sync,
+    {
+        if calls.is_empty() {
+            Err(SessionError::NoCallsPermited)?;
+        }
+
+        self.calls = Vec::with_capacity(calls.len());
+
+        for i in 0..(calls.len() as u64) {
+            let proof = account
+                .compute_proof(&calls, &i)
+                .call()
+                .await
+                .map_err(|_| SessionError::ChainCallFailed)?;
+            let call_with_proof = CallWithProof(calls[i as usize].clone(), proof);
+            self.calls.push(call_with_proof);
+        }
+
+        self.root = account
+            .compute_root(&calls[0], &self.calls[0].1)
+            .call()
+            .await
+            .map_err(|_| SessionError::ChainCallFailed)?;
+
+        Ok(())
     }
 }
 
@@ -33,7 +74,8 @@ impl Default for Session {
         Self {
             session_expires: u64::MAX,
             session_token: vec![felt!("0x2137")],
-            permitted_calls: vec![],
+            calls: vec![],
+            root: felt!("0x2137"),
         }
     }
 }

--- a/account_sdk/src/session_token/session.rs
+++ b/account_sdk/src/session_token/session.rs
@@ -1,12 +1,11 @@
 use std::vec;
 
 use starknet::{
-    accounts::{Account, ConnectedAccount},
     core::{crypto::Signature, types::FieldElement},
     signers::VerifyingKey,
 };
 
-use crate::abigen::account::{Call, CartridgeAccount, SessionSignature, SignatureProofs};
+use crate::abigen::account::{Call, SessionSignature, SignatureProofs};
 
 use super::{
     hash::{self, calculate_merkle_proof, compute_call_hash, compute_root},
@@ -58,16 +57,12 @@ impl Session {
         &self.calls[position]
     }
 
-    pub async fn set_policy<A>(
+    pub async fn set_policy(
         &mut self,
         calls: Vec<Call>,
-        account: CartridgeAccount<A>,
         chain_id: FieldElement,
         address: FieldElement,
-    ) -> Result<FieldElement, SessionError>
-    where
-        A: Account + ConnectedAccount + Sync,
-    {
+    ) -> Result<FieldElement, SessionError> {
         if calls.is_empty() {
             Err(SessionError::NoCallsPermited)?;
         }

--- a/account_sdk/src/session_token/session.rs
+++ b/account_sdk/src/session_token/session.rs
@@ -8,7 +8,7 @@ use starknet::{
 
 use crate::abigen::account::{Call, CartridgeAccount, SessionSignature, SignatureProofs};
 
-use super::SESSION_SIGNATURE_TYPE;
+use super::{hash, SESSION_SIGNATURE_TYPE};
 
 #[derive(Clone)]
 pub struct CallWithProof(pub Call, pub Vec<FieldElement>);
@@ -59,6 +59,8 @@ impl Session {
         &mut self,
         calls: Vec<Call>,
         account: CartridgeAccount<A>,
+        chain_id: FieldElement,
+        address: FieldElement,
     ) -> Result<FieldElement, SessionError>
     where
         A: Account + ConnectedAccount + Sync,
@@ -88,11 +90,7 @@ impl Session {
         // Only three fields are hashed: session_key, session_expires and root
         let signature = self.partial_signature();
 
-        let session_hash = account
-            .compute_session_hash(&signature)
-            .call()
-            .await
-            .map_err(|_| SessionError::ChainCallFailed)?;
+        let session_hash = hash::compute_session_hash(signature, chain_id, address);
 
         Ok(session_hash)
     }

--- a/account_sdk/src/session_token/session.rs
+++ b/account_sdk/src/session_token/session.rs
@@ -3,7 +3,6 @@ use std::vec;
 use starknet::{
     accounts::{Account, ConnectedAccount},
     core::{crypto::Signature, types::FieldElement},
-    macros::felt,
     signers::VerifyingKey,
 };
 
@@ -54,7 +53,7 @@ impl Session {
         &self.calls[position]
     }
 
-    pub async fn set_permitted_calls<A>(
+    pub async fn set_policy<A>(
         &mut self,
         calls: Vec<Call>,
         account: CartridgeAccount<A>,
@@ -118,6 +117,11 @@ impl Session {
         call_position: usize,
     ) -> SessionSignature {
         let CallWithProof(_, proof) = &self.calls[call_position];
+
+        assert!(
+            self.session_token().is_empty() == false,
+            "Session token is empty"
+        );
 
         SessionSignature {
             signature_type: SESSION_SIGNATURE_TYPE,

--- a/account_sdk/src/session_token/session.rs
+++ b/account_sdk/src/session_token/session.rs
@@ -9,7 +9,7 @@ use starknet::{
 use crate::abigen::account::{Call, CartridgeAccount, SessionSignature, SignatureProofs};
 
 use super::{
-    hash::{self, calculate_merkle_proof, compute_call_hash},
+    hash::{self, calculate_merkle_proof, compute_call_hash, compute_root},
     SESSION_SIGNATURE_TYPE,
 };
 
@@ -82,11 +82,7 @@ impl Session {
             self.calls.push(call_with_proof);
         }
 
-        self.root = account
-            .compute_root(&calls[0], &self.calls[0].1)
-            .call()
-            .await
-            .map_err(|_| SessionError::ChainCallFailed)?;
+        self.root = compute_root(call_hashes[0], self.calls[0].1.clone());
 
         // Only three fields are hashed: session_key, session_expires and root
         let signature = self.partial_signature();

--- a/account_sdk/src/session_token/test_utils.rs
+++ b/account_sdk/src/session_token/test_utils.rs
@@ -44,7 +44,12 @@ where
     let session_key = LocalWallet::from(SigningKey::from_random());
     let mut session = Session::new(session_key.get_public_key().await.unwrap(), u64::MAX);
     let session_hash = session
-        .set_policy(permited_calls, cartridge_account)
+        .set_policy(
+            permited_calls,
+            cartridge_account,
+            master_account.chain_id(),
+            master_account.address(),
+        )
         .await
         .unwrap();
 

--- a/account_sdk/src/session_token/test_utils.rs
+++ b/account_sdk/src/session_token/test_utils.rs
@@ -8,10 +8,7 @@ use starknet::{
 
 use crate::session_token::SessionAccount;
 use crate::tests::deployment_test::create_account;
-use crate::{
-    abigen::account::{Call, CartridgeAccount},
-    tests::runners::TestnetRunner,
-};
+use crate::{abigen::account::Call, tests::runners::TestnetRunner};
 
 use super::Session;
 
@@ -31,7 +28,6 @@ where
     let (master_account, master_key) = create_account(&from).await;
 
     let address = master_account.address();
-    let cartridge_account = CartridgeAccount::new(address, &master_account);
     let cainome_address = ContractAddress::from(address);
 
     let call = Call {
@@ -46,7 +42,6 @@ where
     let session_hash = session
         .set_policy(
             permited_calls,
-            cartridge_account,
             master_account.chain_id(),
             master_account.address(),
         )

--- a/account_sdk/src/session_token/test_utils.rs
+++ b/account_sdk/src/session_token/test_utils.rs
@@ -1,12 +1,13 @@
+use cainome::cairo_serde::ContractAddress;
 use starknet::{
     accounts::{Account, ConnectedAccount, SingleOwnerAccount},
     core::types::FieldElement,
     macros::selector,
     providers::{jsonrpc::HttpTransport, JsonRpcClient},
-    signers::{LocalWallet, SigningKey},
+    signers::{LocalWallet, Signer, SigningKey},
 };
 
-use crate::abigen::account::Call;
+use crate::abigen::account::{Call, CartridgeAccount};
 use crate::session_token::SessionAccount;
 use crate::tests::deployment_test::create_account;
 
@@ -14,24 +15,35 @@ use super::Session;
 
 pub async fn create_session_account<'a>(
     from: &SingleOwnerAccount<&'a JsonRpcClient<HttpTransport>, LocalWallet>,
-) -> SessionAccount<&'a JsonRpcClient<HttpTransport>, LocalWallet> {
-    let (provider, chain_id) = (from.provider(), from.chain_id());
+) -> (
+    SessionAccount<&'a JsonRpcClient<HttpTransport>, LocalWallet>,
+    SigningKey,
+) {
+    let (provider, chain_id) = (*from.provider(), from.chain_id());
 
-    let master = create_account(from).await;
-    let address = master.address();
-    let cainome_address = cainome::cairo_serde::ContractAddress::from(address);
+    let (master_account, master_key) = create_account(from).await;
+
+    let address = master_account.address();
+    let cartridge_account = CartridgeAccount::new(address, &master_account);
+    let cainome_address = ContractAddress::from(address);
 
     let call = Call {
         to: cainome_address,
         selector: selector!("revoke_session"),
-        calldata: vec![FieldElement::from(0x2137u32)],
+        calldata: vec![],
     };
-
-    let mut session = Session::default();
     let permited_calls = vec![call];
-    session.set_permitted_calls(permited_calls);
 
     let session_key = LocalWallet::from(SigningKey::from_random());
+    let mut session = Session::new(session_key.get_public_key().await.unwrap(), u64::MAX);
+    let session_hash = session
+        .set_permitted_calls(permited_calls, cartridge_account)
+        .await
+        .unwrap();
 
-    SessionAccount::new(provider, session_key, session, address, chain_id)
+    let session_token = master_key.sign(&session_hash).unwrap();
+    session.set_token(session_token);
+    let session_account = SessionAccount::new(provider, session_key, session, address, chain_id);
+
+    (session_account, master_key)
 }

--- a/cartridge_account/src/lib.cairo
+++ b/cartridge_account/src/lib.cairo
@@ -122,7 +122,7 @@ mod Account {
             if signature_type == starknet::VALIDATED {
                 starknet::VALIDATED
             } else if signature_type == 'Session Token v1' {
-                SessionImpl::validate_session(self, tx_info.signature, calls.span())
+                SessionImpl::validate_session(self, self.get_public_key(), tx_info.signature, calls.span())
             } else {
                 signature_type
             }

--- a/cartridge_account/src/lib.cairo
+++ b/cartridge_account/src/lib.cairo
@@ -52,6 +52,8 @@ mod Account {
     component!(path: session_component, storage: session, event: SessionEvent);
     #[abi(embed_v0)]
     impl SessionImpl = session_component::Session<ContractState>;
+    #[abi(embed_v0)]
+    impl SessionCamelImpl = session_component::SessionCamel<ContractState>;
 
     #[storage]
     struct Storage {
@@ -122,7 +124,7 @@ mod Account {
             if signature_type == starknet::VALIDATED {
                 starknet::VALIDATED
             } else if signature_type == 'Session Token v1' {
-                SessionImpl::validate_session(self, self.get_public_key(), tx_info.signature, calls.span())
+                SessionImpl::validate_session_serialized(self, self.get_public_key(), tx_info.signature, calls.span())
             } else {
                 signature_type
             }

--- a/src/session/src/interface.cairo
+++ b/src/session/src/interface.cairo
@@ -1,0 +1,27 @@
+use starknet::account::Call;
+
+use webauthn_session::signature::{SessionSignature, SignatureProofs, SignatureProofsTrait};
+
+
+#[starknet::interface]
+trait ISession<TContractState> {
+    fn validate_session(self: @TContractState, public_key: felt252, signature: SessionSignature, calls: Span<Call>) -> felt252;
+    fn validate_session_serialized(self: @TContractState, public_key: felt252, signature: Span<felt252>, calls: Span<Call>) -> felt252;
+    fn revoke_session(ref self: TContractState, token: Span<felt252>);
+
+    fn compute_proof(self: @TContractState, calls: Array<Call>, position: u64) -> Span<felt252>;
+    fn compute_root(self: @TContractState, call: Call, proof: Span<felt252>) -> felt252;
+    fn compute_session_hash(self: @TContractState, unsigned_signature: SessionSignature) -> felt252;
+}
+
+#[starknet::interface]
+trait ISessionCamel<TContractState> {
+    fn validateSession(self: @TContractState, publicKey: felt252, signature: SessionSignature, calls: Span<Call>) -> felt252;
+    fn validateSessionSerialized(self: @TContractState, publicKey: felt252, signature: Span<felt252>, calls: Span<Call>) -> felt252;
+    fn revokeSession(ref self: TContractState, token: Span<felt252>);
+
+    fn computeProof(self: @TContractState, calls: Array<Call>, position: u64) -> Span<felt252>;
+    fn computeRoot(self: @TContractState, call: Call, proof: Span<felt252>) -> felt252;
+    fn computeSessionHash(self: @TContractState, unsignedSignature: SessionSignature) -> felt252;
+}
+

--- a/src/session/src/signature.cairo
+++ b/src/session/src/signature.cairo
@@ -2,6 +2,9 @@ use core::integer::U32Div;
 use core::Into;
 use debug::PrintTrait;
 
+// The layout of the span should look like:
+// [r, s, session_key, session_expires, root, proof_len, proofs_len, { proofs ... } , session_token_len, { session_token ... }]
+
 #[derive(Copy, Drop, Serde)]
 struct SessionSignature {
     signature_type: felt252,
@@ -12,43 +15,6 @@ struct SessionSignature {
     root: felt252,
     proofs: SignatureProofs,
     session_token: Span<felt252>
-}
-
-impl FeltSpanTryIntoSignature of TryInto<Span<felt252>, SessionSignature> {
-    // Convert a span of felts to SessionSignature struct
-    // The layout of the span should look like:
-    // [r, s, session_key, session_expires, root, proof_len, proofs_len, { proofs ... } , session_token_len, { session_token ... }]
-    //                                                                   ^-proofs_len-^                      ^-session_token_len-^
-    // See details in the implementation
-    fn try_into(self: Span<felt252>) -> Option<SessionSignature> {
-        let single_proof_len: usize = (*self[7]).try_into()?;
-        let total_proofs_len: usize = (*self[8]).try_into()?;
-        let session_token_offset: usize = 9 + total_proofs_len;
-        let session_token_len: usize = (*self[session_token_offset]).try_into()?;
-
-        if self.len() != session_token_offset + 1 + session_token_len {
-            return Option::None(());
-        }
-
-        let session_token: Span<felt252> = self
-            .slice(session_token_offset + 1, session_token_len);
-
-        let proofs_flat: Span<felt252> = self.slice(9, total_proofs_len);
-        let proofs = ImplSignatureProofs::try_new(proofs_flat, single_proof_len)?;
-
-        Option::Some(
-            SessionSignature {
-                signature_type: *self[0],
-                r: *self[2],
-                s: *self[3],
-                session_key: *self[4],
-                session_expires: (*self[5]).try_into()?,
-                root: *self[6],
-                proofs: proofs,
-                session_token: session_token
-            }
-        )
-    }
 }
 
 #[derive(Copy, Drop, Serde)]


### PR DESCRIPTION
This PR fills all the holes to complete the session token signature. 

1. Resolving calls to attach appropriate proofs (from a prepared vector)
2. Session token as a signature of hash of the session signature structure
3. Camel case interface
4. Overall cleanup
5. Some comments to allow for easier maintnance