### PR TITLE
1/6 rust hashing

### DIFF
--- a/account_sdk/Cargo.toml
+++ b/account_sdk/Cargo.toml
@@ -31,3 +31,4 @@ webauthn-rs-proto = "0.4.9"
 base64 = "0.21.5"
 sha2 = "0.10.8"
 cainome = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.1.0", features = ["abigen-rs"] }
+starknet-crypto = "0.6.1"

--- a/account_sdk/src/session_token/hash.rs
+++ b/account_sdk/src/session_token/hash.rs
@@ -18,7 +18,7 @@ const POLICY_TYPE_HASH: FieldElement =
 
 const STARKNET_MESSAGE_FELT: FieldElement = felt!("0x537461726b4e6574204d657373616765");
 
-fn compute_session_hash(
+pub fn compute_session_hash(
     signature: SessionSignature,
     chain_id: FieldElement,
     account: FieldElement,
@@ -37,7 +37,7 @@ fn compute_session_hash(
     hasher.finalize()
 }
 
-fn compute_call_hash(call: &Call) -> FieldElement {
+pub fn compute_call_hash(call: &Call) -> FieldElement {
     let mut hasher = PoseidonHasher::new();
     hasher.update(POLICY_TYPE_HASH);
     hasher.update((call.to).into());
@@ -45,14 +45,14 @@ fn compute_call_hash(call: &Call) -> FieldElement {
     hasher.finalize()
 }
 
-fn hash_domain(chain_id: FieldElement) -> FieldElement {
+pub fn hash_domain(chain_id: FieldElement) -> FieldElement {
     let mut hasher = PoseidonHasher::new();
     hasher.update(STARKNET_DOMAIN_TYPE_HASH);
     hasher.update(chain_id);
     hasher.finalize()
 }
 
-fn hash_message(
+pub fn hash_message(
     session_key: FieldElement,
     session_expires: FieldElement,
     root: FieldElement,

--- a/account_sdk/src/session_token/hash.rs
+++ b/account_sdk/src/session_token/hash.rs
@@ -78,6 +78,24 @@ pub fn calculate_merkle_proof(call_hashes: &Vec<FieldElement>, index: usize) -> 
     proof
 }
 
+pub fn compute_root(mut current_node: FieldElement, mut proof: Vec<FieldElement>) -> FieldElement {
+    loop {
+        if proof.is_empty() {
+            break current_node;
+        }
+
+        let proof_element = proof.remove(0);
+        // Compute the hash of the current node and the current element of the proof.
+        // We need to check if the current node is smaller than the current element of the proof.
+        // If it is, we need to swap the order of the hash.
+        current_node = if current_node < proof_element {
+            hash_two_elements(current_node, proof_element)
+        } else {
+            hash_two_elements(proof_element, current_node)
+        };
+    }
+}
+
 // based on: https://github.com/keep-starknet-strange/alexandria/blob/ecc881e2aee668332441bdfa32336e3404cf8eb1/src/merkle_tree/src/merkle_tree.cairo#L182C4-L215
 fn compute_proof(mut nodes: Vec<FieldElement>, index: usize, proof: &mut Vec<FieldElement>) {
     // Break if we have reached the top of the tree

--- a/account_sdk/src/session_token/hash.rs
+++ b/account_sdk/src/session_token/hash.rs
@@ -1,5 +1,5 @@
 use starknet::{core::types::FieldElement, macros::felt};
-use starknet_crypto::PoseidonHasher;
+use starknet_crypto::{poseidon_hash, PoseidonHasher};
 
 use crate::abigen::account::{Call, SessionSignature};
 
@@ -17,6 +17,13 @@ const POLICY_TYPE_HASH: FieldElement =
     felt!("0x2f0026e78543f036f33e26a8f5891b88c58dc1e20cbbfaf0bb53274da6fa568");
 
 const STARKNET_MESSAGE_FELT: FieldElement = felt!("0x537461726b4e6574204d657373616765");
+
+fn hash_two_elements(a: FieldElement, b: FieldElement) -> FieldElement {
+    let mut hasher = PoseidonHasher::new();
+    hasher.update(a);
+    hasher.update(b);
+    hasher.finalize()
+}
 
 pub fn compute_session_hash(
     signature: SessionSignature,
@@ -63,4 +70,101 @@ pub fn hash_message(
     hasher.update(session_expires);
     hasher.update(root);
     hasher.finalize()
+}
+
+// based on: https://github.com/keep-starknet-strange/alexandria/blob/ecc881e2aee668332441bdfa32336e3404cf8eb1/src/merkle_tree/src/merkle_tree.cairo#L182C4-L215
+pub fn compute_proof(mut nodes: Vec<FieldElement>, index: usize, proof: &mut Vec<FieldElement>) {
+    // Break if we have reached the top of the tree
+    if nodes.len() == 1 {
+        return;
+    }
+
+    // If odd number of nodes, add a null virtual leaf
+    if nodes.len() % 2 != 0 {
+        nodes.push(FieldElement::ZERO);
+    }
+
+    // Compute next level
+    let next_level = get_next_level(nodes.clone());
+
+    // Find neighbor node
+    let index_parent;
+    let mut i = 0usize;
+    loop {
+        if i == index {
+            index_parent = i / 2;
+            if i % 2 == 0 {
+                proof.push(nodes[i + 1]);
+            } else {
+                proof.push(nodes[i - 1]);
+            }
+            break;
+        }
+        i += 1;
+    }
+
+    compute_proof(next_level, index_parent, proof)
+}
+
+fn get_next_level(mut nodes: Vec<FieldElement>) -> Vec<FieldElement> {
+    let mut next_level: Vec<FieldElement> = Vec::with_capacity(nodes.len() / 2);
+    while !nodes.is_empty() {
+        let left = nodes.remove(0);
+        let right = nodes.remove(0);
+
+        let node = if left < right {
+            hash_two_elements(left, right)
+        } else {
+            hash_two_elements(right, left)
+        };
+        next_level.push(node);
+    }
+    next_level
+}
+
+// Example from https://github.com/keep-starknet-strange/alexandria/blob/ecc881e2aee668332441bdfa32336e3404cf8eb1/src/merkle_tree/src/tests/merkle_tree_test.cairo#L104-L151
+#[test]
+fn merkle_tree_poseidon_test() {
+    // [Setup] Merkle tree.
+    let root = felt!("0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47");
+    let leaf = 0x1;
+    let valid_proof = vec![
+        felt!("0x2"),
+        felt!("0x47ef3ad11ad3f8fc055281f1721acd537563ec134036bc4bd4de2af151f0832"),
+    ];
+    let leaves = vec![felt!("0x1"), felt!("0x2"), felt!("0x3")];
+
+    // // [Assert] Compute merkle root.
+    // let computed_root = compute_root(leaf, valid_proof);
+    // assert(computed_root == root, 'compute valid root failed');
+
+    // [Assert] Compute merkle proof.
+    let mut input_leaves = leaves;
+    let index = 0;
+    let mut computed_proof = vec![];
+    compute_proof(input_leaves, index, &mut computed_proof);
+    assert_eq!(computed_proof, valid_proof, "compute valid proof failed");
+
+    // // [Assert] Verify a valid proof.
+    // let result = MerkleTreeImpl::<
+    //     _, PoseidonHasherImpl
+    // >::verify(ref merkle_tree, root, leaf, valid_proof);
+    // assert(result, 'verify valid proof failed');
+
+    // // [Assert] Verify an invalid proof.
+    // let invalid_proof = array![
+    //     0x2 + 1, 0x68ba2a188dd231112c1cb5aaa5d18be6d84f6c8683e5c3a6638dee83e727acc
+    // ]
+    //     .span();
+    // let result = MerkleTreeImpl::<
+    //     _, PoseidonHasherImpl
+    // >::verify(ref merkle_tree, root, leaf, invalid_proof);
+    // assert(!result, 'verify invalid proof failed');
+
+    // // [Assert] Verify a valid proof with an invalid leaf.
+    // let invalid_leaf = 0x1 + 1;
+    // let result = MerkleTreeImpl::<
+    //     _, PoseidonHasherImpl
+    // >::verify(ref merkle_tree, root, invalid_leaf, valid_proof);
+    // assert(!result, 'wrong result');
 }

--- a/account_sdk/src/session_token/hash.rs
+++ b/account_sdk/src/session_token/hash.rs
@@ -1,0 +1,66 @@
+use starknet::{core::types::FieldElement, macros::felt};
+use starknet_crypto::PoseidonHasher;
+
+use crate::abigen::account::{Call, SessionSignature};
+
+// needs to behave anologously to https://github.com/keep-starknet-strange/alexandria,
+// which uses starknets hash, reimplemented here https://github.com/starkware-libs/cairo-lang/blob/12ca9e91bbdc8a423c63280949c7e34382792067/src/starkware/cairo/common/poseidon_hash.py#L46
+
+// H('StarkNetDomain(chainId:felt)')
+const STARKNET_DOMAIN_TYPE_HASH: FieldElement =
+    felt!("0x13cda234a04d66db62c06b8e3ad5f91bd0c67286c2c7519a826cf49da6ba478");
+// H('Session(key:felt,expires:felt,root:merkletree)')
+const SESSION_TYPE_HASH: FieldElement =
+    felt!("0x1aa0e1c56b45cf06a54534fa1707c54e520b842feb21d03b7deddb6f1e340c");
+// H(Policy(contractAddress:felt,selector:selector))
+const POLICY_TYPE_HASH: FieldElement =
+    felt!("0x2f0026e78543f036f33e26a8f5891b88c58dc1e20cbbfaf0bb53274da6fa568");
+
+const STARKNET_MESSAGE_FELT: FieldElement = felt!("0x537461726b4e6574204d657373616765");
+
+fn compute_session_hash(
+    signature: SessionSignature,
+    chain_id: FieldElement,
+    account: FieldElement,
+) -> FieldElement {
+    let domain_hash = hash_domain(chain_id);
+    let message_hash = hash_message(
+        signature.session_key,
+        signature.session_expires.into(),
+        signature.root,
+    );
+    let mut hasher = PoseidonHasher::new();
+    hasher.update(STARKNET_MESSAGE_FELT);
+    hasher.update(domain_hash);
+    hasher.update(account.into());
+    hasher.update(message_hash);
+    hasher.finalize()
+}
+
+fn compute_call_hash(call: &Call) -> FieldElement {
+    let mut hasher = PoseidonHasher::new();
+    hasher.update(POLICY_TYPE_HASH);
+    hasher.update((call.to).into());
+    hasher.update(call.selector);
+    hasher.finalize()
+}
+
+fn hash_domain(chain_id: FieldElement) -> FieldElement {
+    let mut hasher = PoseidonHasher::new();
+    hasher.update(STARKNET_DOMAIN_TYPE_HASH);
+    hasher.update(chain_id);
+    hasher.finalize()
+}
+
+fn hash_message(
+    session_key: FieldElement,
+    session_expires: FieldElement,
+    root: FieldElement,
+) -> FieldElement {
+    let mut hasher = PoseidonHasher::new();
+    hasher.update(SESSION_TYPE_HASH);
+    hasher.update(session_key);
+    hasher.update(session_expires);
+    hasher.update(root);
+    hasher.finalize()
+}

--- a/account_sdk/src/session_token/hash.rs
+++ b/account_sdk/src/session_token/hash.rs
@@ -72,8 +72,14 @@ pub fn hash_message(
     hasher.finalize()
 }
 
+pub fn calculate_merkle_proof(call_hashes: &Vec<FieldElement>, index: usize) -> Vec<FieldElement> {
+    let mut proof = vec![];
+    compute_proof(call_hashes.clone(), index, &mut proof);
+    proof
+}
+
 // based on: https://github.com/keep-starknet-strange/alexandria/blob/ecc881e2aee668332441bdfa32336e3404cf8eb1/src/merkle_tree/src/merkle_tree.cairo#L182C4-L215
-pub fn compute_proof(mut nodes: Vec<FieldElement>, index: usize, proof: &mut Vec<FieldElement>) {
+fn compute_proof(mut nodes: Vec<FieldElement>, index: usize, proof: &mut Vec<FieldElement>) {
     // Break if we have reached the top of the tree
     if nodes.len() == 1 {
         return;

--- a/account_sdk/src/session_token/mod.rs
+++ b/account_sdk/src/session_token/mod.rs
@@ -125,7 +125,7 @@ mod tests {
         // Letting the session revoke itself
         account.revoke_session(&session_token).send().await.unwrap();
 
-        sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(200)).await;
 
         // The session should not be able to sign calls anymore
         let revoked_token = vec![FieldElement::from(0x2137u32), FieldElement::from(0x2137u32)];

--- a/account_sdk/src/session_token/mod.rs
+++ b/account_sdk/src/session_token/mod.rs
@@ -1,4 +1,5 @@
 mod account;
+mod hash;
 mod sequence;
 mod session;
 #[cfg(test)]

--- a/account_sdk/src/session_token/mod.rs
+++ b/account_sdk/src/session_token/mod.rs
@@ -45,8 +45,6 @@ mod tests {
         // Initialize a cartridge account, funding it from the prefunded account
         let prefunded_account = runner.prefunded_single_owner_account().await;
         let (master_account, master_key) = create_account(&prefunded_account).await;
-        let master_cartridge_account =
-            CartridgeAccount::new(master_account.address(), &master_account);
 
         // Creating a session, that will be used to sign calls
         let session_key = SigningKey::from_secret_scalar(FieldElement::from(2137u32));
@@ -65,7 +63,6 @@ mod tests {
         let session_hash = session
             .set_policy(
                 permitted_calls,
-                master_cartridge_account,
                 master_account.chain_id(),
                 master_account.address(),
             )
@@ -139,8 +136,6 @@ mod tests {
         // Initializing a prepared session account and master account
         let (mut session_account, master_key, master_account) =
             create_session_account(&runner).await;
-        let master_cartridge_account =
-            CartridgeAccount::new(session_account.address(), &master_account);
 
         // Setting a single allowed call, not including the one later called
         let permitted_calls = vec![Call {
@@ -154,7 +149,6 @@ mod tests {
         let session_hash = session
             .set_policy(
                 permitted_calls,
-                master_cartridge_account,
                 master_account.chain_id(),
                 master_account.address(),
             )
@@ -178,8 +172,6 @@ mod tests {
         // Initializing a prepared session account and master account
         let (mut session_account, master_key, master_account) =
             create_session_account(&runner).await;
-        let master_cartridge_account =
-            CartridgeAccount::new(session_account.address(), &master_account);
 
         // Defining multiple allowed calls
         let to = ContractAddress::from(session_account.address());
@@ -209,7 +201,6 @@ mod tests {
         let session_hash = session
             .set_policy(
                 permitted_calls,
-                master_cartridge_account,
                 master_account.chain_id(),
                 master_account.address(),
             )

--- a/account_sdk/src/session_token/session.rs
+++ b/account_sdk/src/session_token/session.rs
@@ -1,12 +1,11 @@
 use std::vec;
 
 use starknet::{
-    accounts::{Account, ConnectedAccount},
     core::{crypto::Signature, types::FieldElement},
     signers::VerifyingKey,
 };
 
-use crate::abigen::account::{Call, CartridgeAccount, SessionSignature, SignatureProofs};
+use crate::abigen::account::{Call, SessionSignature, SignatureProofs};
 
 use super::{
     hash::{self, calculate_merkle_proof, compute_call_hash, compute_root},
@@ -58,16 +57,12 @@ impl Session {
         &self.calls[position]
     }
 
-    pub async fn set_policy<A>(
+    pub async fn set_policy(
         &mut self,
         calls: Vec<Call>,
-        account: CartridgeAccount<A>,
         chain_id: FieldElement,
         address: FieldElement,
-    ) -> Result<FieldElement, SessionError>
-    where
-        A: Account + ConnectedAccount + Sync,
-    {
+    ) -> Result<FieldElement, SessionError> {
         if calls.is_empty() {
             Err(SessionError::NoCallsPermited)?;
         }

--- a/account_sdk/src/session_token/session.rs
+++ b/account_sdk/src/session_token/session.rs
@@ -8,7 +8,7 @@ use starknet::{
 
 use crate::abigen::account::{Call, CartridgeAccount, SessionSignature, SignatureProofs};
 
-use super::SESSION_SIGNATURE_TYPE;
+use super::{hash, SESSION_SIGNATURE_TYPE};
 
 #[derive(Clone)]
 pub struct CallWithProof(pub Call, pub Vec<FieldElement>);
@@ -59,6 +59,8 @@ impl Session {
         &mut self,
         calls: Vec<Call>,
         account: CartridgeAccount<A>,
+        chain_id: FieldElement,
+        address: FieldElement,
     ) -> Result<FieldElement, SessionError>
     where
         A: Account + ConnectedAccount + Sync,
@@ -88,11 +90,7 @@ impl Session {
         // Only three fields are hashed: session_key, session_expires and root
         let signature = self.partial_signature();
 
-        let session_hash = account
-            .compute_session_hash(&signature)
-            .call()
-            .await
-            .map_err(|_| SessionError::ChainCallFailed)?;
+        let session_hash = hash::compute_session_hash(signature, chain_id, address);
 
         Ok(session_hash)
     }

--- a/account_sdk/src/session_token/session.rs
+++ b/account_sdk/src/session_token/session.rs
@@ -9,7 +9,7 @@ use starknet::{
 use crate::abigen::account::{Call, CartridgeAccount, SessionSignature, SignatureProofs};
 
 use super::{
-    hash::{self, calculate_merkle_proof, compute_call_hash},
+    hash::{self, calculate_merkle_proof, compute_call_hash, compute_root},
     SESSION_SIGNATURE_TYPE,
 };
 
@@ -82,11 +82,7 @@ impl Session {
             self.calls.push(call_with_proof);
         }
 
-        self.root = account
-            .compute_root(&calls[0], &self.calls[0].1)
-            .call()
-            .await
-            .map_err(|_| SessionError::ChainCallFailed)?;
+        self.root = compute_root(call_hashes[0], self.calls[0].1.clone());
 
         // Only three fields are hashed: session_key, session_expires and root
         let signature = self.partial_signature();

--- a/account_sdk/src/session_token/test_utils.rs
+++ b/account_sdk/src/session_token/test_utils.rs
@@ -44,7 +44,12 @@ where
     let session_key = LocalWallet::from(SigningKey::from_random());
     let mut session = Session::new(session_key.get_public_key().await.unwrap(), u64::MAX);
     let session_hash = session
-        .set_policy(permited_calls, cartridge_account)
+        .set_policy(
+            permited_calls,
+            cartridge_account,
+            master_account.chain_id(),
+            master_account.address(),
+        )
         .await
         .unwrap();
 

--- a/account_sdk/src/session_token/test_utils.rs
+++ b/account_sdk/src/session_token/test_utils.rs
@@ -8,10 +8,7 @@ use starknet::{
 
 use crate::session_token::SessionAccount;
 use crate::tests::deployment_test::create_account;
-use crate::{
-    abigen::account::{Call, CartridgeAccount},
-    tests::runners::TestnetRunner,
-};
+use crate::{abigen::account::Call, tests::runners::TestnetRunner};
 
 use super::Session;
 
@@ -31,7 +28,6 @@ where
     let (master_account, master_key) = create_account(&from).await;
 
     let address = master_account.address();
-    let cartridge_account = CartridgeAccount::new(address, &master_account);
     let cainome_address = ContractAddress::from(address);
 
     let call = Call {
@@ -46,7 +42,6 @@ where
     let session_hash = session
         .set_policy(
             permited_calls,
-            cartridge_account,
             master_account.chain_id(),
             master_account.address(),
         )


### PR DESCRIPTION
This pr has the sole focus of moving proving and hashing from cairo to Rust. Using the official implementation of poseidon hash and a implementation of merkle tree analogous to [Alexandira's](https://github.com/keep-starknet-strange/alexandria) allowed for a painless migration. 