### PR TITLE
Feat/4/2 Auth tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ url = "2"
 wasm-bindgen = "0.2"
 webauthn-authenticator-rs = { version = "0.4" }
 webauthn-rs-proto = "0.4"
+account-sdk = { path = "crates/account_sdk" }

--- a/crates/account_sdk/Cargo.toml
+++ b/crates/account_sdk/Cargo.toml
@@ -6,7 +6,7 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/account_sdk/src/session_token/session.rs
+++ b/crates/account_sdk/src/session_token/session.rs
@@ -106,6 +106,8 @@ impl Session {
             Ok(acc)
         })?;
 
+        assert!(!self.session_token().is_empty(), "Session token is empty");
+
         Ok(SessionSignature {
             signature_type: SESSION_SIGNATURE_TYPE,
             r: transaction_signature.r,

--- a/crates/account_sdk/src/session_token/session.rs
+++ b/crates/account_sdk/src/session_token/session.rs
@@ -101,14 +101,10 @@ impl Session {
             .map(|c| self.call_proof(c).ok_or(SessionError::CallNotInPolicy))
             .collect::<Result<Vec<_>, SessionError>>()?;
 
-        let proofs_flat = proofs.into_iter().fold(Ok(vec![]), |acc, proof| {
-            acc.and_then(|mut acc| {
-                acc.extend(proof.1.clone());
-                Ok(acc)
-            })
+        let proofs_flat = proofs.into_iter().try_fold(vec![], |mut acc, proof| {
+            acc.extend(proof.1.clone());
+            Ok(acc)
         })?;
-
-        assert!(!self.session_token().is_empty(), "Session token is empty");
 
         Ok(SessionSignature {
             signature_type: SESSION_SIGNATURE_TYPE,

--- a/crates/webauthn/auth/src/deserializable_endpoints.cairo
+++ b/crates/webauthn/auth/src/deserializable_endpoints.cairo
@@ -1,0 +1,16 @@
+use webauthn_auth::types::PublicKey;
+use webauthn_auth::ecdsa::VerifyEcdsaError;
+use starknet::secp256r1::Secp256r1Point;
+use webauthn_auth::errors::{AuthnError, RTSEIntoRTAE, AuthnErrorIntoFelt252};
+use webauthn_auth::ecdsa::verify_hashed_ecdsa;
+use core::traits::Into;
+
+fn verify_hashed_ecdsa_endpoint(
+    public_key_pt: PublicKey, msg_hash: u256, r: u256, s: u256
+) -> Result<(), VerifyEcdsaError> {
+    let pub_key_point: Secp256r1Point = match public_key_pt.try_into() {
+        Option::Some(p) => p,
+        Option::None => { return Result::Err(VerifyEcdsaError::WrongArgument); }
+    };
+    verify_hashed_ecdsa(pub_key_point, msg_hash, r, s)
+}

--- a/crates/webauthn/auth/src/deserializable_endpoints.cairo
+++ b/crates/webauthn/auth/src/deserializable_endpoints.cairo
@@ -6,6 +6,7 @@ use webauthn_auth::ecdsa::verify_hashed_ecdsa;
 use core::traits::Into;
 use webauthn_auth::webauthn::ImplArrayu8TryIntoAuthData;
 use webauthn_auth::types::AuthenticatorData;
+use webauthn_auth::helpers::extract_u256_from_u8_array;
 
 fn verify_hashed_ecdsa_endpoint(
     public_key_pt: PublicKey, msg_hash: u256, r: u256, s: u256
@@ -22,4 +23,8 @@ fn expand_auth_data_endpoint(
 ) -> AuthenticatorData {
     let data: Option<AuthenticatorData> = ImplArrayu8TryIntoAuthData::try_into(auth_data);
     return data.unwrap();
+}
+
+fn extract_u256_from_u8_array_endpoint(bytes: Array<u8>, offset: u32) -> Option<u256> {
+    extract_u256_from_u8_array(@bytes, offset)
 }

--- a/crates/webauthn/auth/src/deserializable_endpoints.cairo
+++ b/crates/webauthn/auth/src/deserializable_endpoints.cairo
@@ -4,6 +4,8 @@ use starknet::secp256r1::Secp256r1Point;
 use webauthn_auth::errors::{AuthnError, RTSEIntoRTAE, AuthnErrorIntoFelt252};
 use webauthn_auth::ecdsa::verify_hashed_ecdsa;
 use core::traits::Into;
+use webauthn_auth::webauthn::ImplArrayu8TryIntoAuthData;
+use webauthn_auth::types::AuthenticatorData;
 
 fn verify_hashed_ecdsa_endpoint(
     public_key_pt: PublicKey, msg_hash: u256, r: u256, s: u256
@@ -13,4 +15,11 @@ fn verify_hashed_ecdsa_endpoint(
         Option::None => { return Result::Err(VerifyEcdsaError::WrongArgument); }
     };
     verify_hashed_ecdsa(pub_key_point, msg_hash, r, s)
+}
+
+fn expand_auth_data_endpoint(
+    auth_data: Array<u8>
+) -> AuthenticatorData {
+    let data: Option<AuthenticatorData> = ImplArrayu8TryIntoAuthData::try_into(auth_data);
+    return data.unwrap();
 }

--- a/crates/webauthn/auth/src/lib.cairo
+++ b/crates/webauthn/auth/src/lib.cairo
@@ -6,6 +6,7 @@ mod helpers;
 mod errors;
 mod component;
 mod interface;
+mod deserializable_endpoints;
 
 #[cfg(test)]
 mod tests;

--- a/crates/webauthn/tests/Cargo.toml
+++ b/crates/webauthn/tests/Cargo.toml
@@ -12,3 +12,4 @@ proptest = "1.4.0"
 p256.workspace = true
 account-sdk.workspace = true
 u256 = "0.1.0"
+sha2.workspace = true

--- a/crates/webauthn/tests/Cargo.toml
+++ b/crates/webauthn/tests/Cargo.toml
@@ -8,3 +8,7 @@ version.workspace = true
 [dependencies]
 starknet.workspace = true
 cairo-args-runner = { path="/home/szymon/dev/cairo-args-runner" }
+proptest = "1.4.0"
+p256.workspace = true
+account-sdk.workspace = true
+u256 = "0.1.0"

--- a/crates/webauthn/tests/Cargo.toml
+++ b/crates/webauthn/tests/Cargo.toml
@@ -7,7 +7,7 @@ version.workspace = true
 
 [dependencies]
 starknet.workspace = true
-cairo-args-runner = { path="/home/szymon/dev/cairo-args-runner" }
+cairo-args-runner = { git="https://github.com/neotheprogramist/cairo-args-runner", branch = "thepinion"}
 proptest = "1.4.0"
 p256.workspace = true
 account-sdk.workspace = true

--- a/crates/webauthn/tests/src/auth/expand_auth_data.rs
+++ b/crates/webauthn/tests/src/auth/expand_auth_data.rs
@@ -44,6 +44,7 @@ pub struct AuthenticatorData {
 }
 
 impl AuthenticatorData {
+    #[allow(dead_code)]
     pub fn from_bytes(bytes: &[u8]) -> Self {
         let rp_id_hash = bytes[0..32].try_into().unwrap();
         let flags = bytes[32];

--- a/crates/webauthn/tests/src/auth/expand_auth_data.rs
+++ b/crates/webauthn/tests/src/auth/expand_auth_data.rs
@@ -1,10 +1,7 @@
 use cairo_args_runner::{Arg, Felt252};
 
 use super::FeltSerialize;
-use crate::{
-    auth::ArgsBuilder, Function, FunctionReturnLength, FunctionTrait, FunctionUnspecified,
-    SpecifiedResultMemory,
-};
+use crate::{auth::ArgsBuilder, FunctionTrait};
 use cairo_args_runner::SuccessfulRun;
 
 struct AuthDataFunction;
@@ -75,7 +72,11 @@ impl FeltSerialize for AuthenticatorData {
 }
 
 fn expand_auth_data(auth_data: AuthenticatorData) -> bool {
-    let result = EXPAND_AUTH_DATA.run(ArgsBuilder::new().add_array(auth_data.clone().to_felts()).build());
+    let result = EXPAND_AUTH_DATA.run(
+        ArgsBuilder::new()
+            .add_array(auth_data.clone().to_felts())
+            .build(),
+    );
     auth_data == result
 }
 

--- a/crates/webauthn/tests/src/auth/expand_auth_data.rs
+++ b/crates/webauthn/tests/src/auth/expand_auth_data.rs
@@ -1,0 +1,62 @@
+use cairo_args_runner::Felt252;
+
+use crate::{
+    auth::ArgsBuilder, Function, FunctionReturnLength, FunctionTrait, FunctionUnspecified,
+};
+
+use super::FeltSerialize;
+
+/// ```extended_gcd(u256, u256) -> (u256, u256, u256)```
+const EXPAND_AUTH_DATA: FunctionUnspecified =
+    Function::new_unspecified("expand_auth_data_endpoint");
+
+pub struct AuthenticatorData {
+    pub rp_id_hash: [u8; 32],
+    pub flags: u8,
+    pub sign_count: u32,
+}
+
+impl AuthenticatorData {
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let rp_id_hash = bytes[0..32].try_into().unwrap();
+        let flags = bytes[32];
+        let sign_count = u32::from_be_bytes(bytes[33..37].try_into().unwrap());
+        Self {
+            rp_id_hash,
+            flags,
+            sign_count,
+        }
+    }
+}
+
+impl FeltSerialize for AuthenticatorData {
+    fn to_felts(self) -> Vec<Felt252> {
+        let mut felts: Vec<_> = self.rp_id_hash.iter().cloned().map(Felt252::from).collect();
+        felts.push(self.flags.into());
+        felts.extend(
+            self.sign_count
+                .to_be_bytes()
+                .iter()
+                .cloned()
+                .map(Felt252::from),
+        );
+        felts
+    }
+}
+
+fn expand_auth_data(auth_data: AuthenticatorData) -> bool {
+    let result = EXPAND_AUTH_DATA.run(ArgsBuilder::new().add_array(auth_data.to_felts()).build());
+    dbg!(result);
+    true
+}
+
+#[test]
+fn test_expand_auth_data_1() {
+    let d: Vec<u8> = (0_u8..32_u8).into_iter().collect();
+    let auth_data = AuthenticatorData {
+        rp_id_hash: d.try_into().unwrap(),
+        flags: 0,
+        sign_count: 0,
+    };
+    assert!(expand_auth_data(auth_data));
+}

--- a/crates/webauthn/tests/src/auth/helpers.rs
+++ b/crates/webauthn/tests/src/auth/helpers.rs
@@ -1,0 +1,71 @@
+use cairo_args_runner::{errors::SierraRunnerError, Arg, Felt252};
+
+use super::CairoU256;
+use crate::{auth::ArgsBuilder, FunctionTrait};
+use cairo_args_runner::SuccessfulRun;
+
+struct Extractu256Fromu8ArrayFunction;
+
+impl FunctionTrait<Option<CairoU256>, (Vec<u8>, usize)> for Extractu256Fromu8ArrayFunction {
+    fn transform_arguments(&self, args: (Vec<u8>, usize)) -> Vec<Arg> {
+        ArgsBuilder::new().add_array(args.0).add_one(args.1).build()
+    }
+
+    fn transform_result(
+        &self,
+        result: Result<SuccessfulRun, SierraRunnerError>,
+    ) -> Option<CairoU256> {
+        let result = result.unwrap();
+        let felts: Vec<Felt252> = result.value;
+        if felts[0] == Felt252::from(1) {
+            None
+        } else {
+            Some(CairoU256 {
+                low: felts[1].clone(),
+                high: felts[2].clone(),
+            })
+        }
+    }
+
+    fn name(&self) -> &str {
+        "extract_u256_from_u8_array_endpoint"
+    }
+}
+
+const EXTRACT_U256_FROM_U8_ARRAY: Extractu256Fromu8ArrayFunction = Extractu256Fromu8ArrayFunction;
+
+fn serialize_and_extract_u256(val: CairoU256, offset: usize) -> CairoU256 {
+    let low = val.low.to_bytes_be();
+    let high = val.high.to_bytes_be();
+
+    let bytes = [
+        vec![0; offset + 16 - high.len()],
+        high,
+        vec![0; 16 - low.len()],
+        low,
+    ]
+    .concat();
+    let result = EXTRACT_U256_FROM_U8_ARRAY.run((bytes, offset));
+    result.unwrap()
+}
+
+#[test]
+fn test_extract_u256_from_u8_array_1() {
+    let result = EXTRACT_U256_FROM_U8_ARRAY.run(([0u8; 32].to_vec(), 0));
+    assert_eq!(result, Some(CairoU256::zero()));
+}
+
+#[test]
+fn test_extract_u256_from_u8_array_2() {
+    let val = CairoU256 {
+        low: Felt252::from(12345),
+        high: Felt252::from(98765),
+    };
+    assert_eq!(serialize_and_extract_u256(val.clone(), 0), val);
+}
+
+#[test]
+fn test_extract_u256_from_u8_array_fail_1() {
+    let result = EXTRACT_U256_FROM_U8_ARRAY.run(([0u8; 32].to_vec(), 3));
+    assert_eq!(result, None);
+}

--- a/crates/webauthn/tests/src/auth/mod.rs
+++ b/crates/webauthn/tests/src/auth/mod.rs
@@ -2,9 +2,66 @@ use cairo_args_runner::{arg_array, arg_value, felt_vec, Arg, Felt252};
 
 mod mod_arithmetic;
 mod verify_signature;
+mod verify_ecdsa;
 
+#[derive(Debug)]
 pub struct ArgsBuilder {
     args: Vec<Arg>,
+}
+
+pub struct CairoU256 {
+    low: Felt252,
+    high: Felt252,
+}
+
+
+impl CairoU256 {
+    pub fn new(low: Felt252, high: Felt252) -> Self {
+        Self { low, high }
+    }
+    pub fn from_bytes_be(low: &[u8; 16], high: &[u8; 16]) -> Self {
+        Self::new(Felt252::from_bytes_be(low), Felt252::from_bytes_be(high))
+    }
+    pub fn from_byte_slice_be(bytes: &[u8; 32]) -> Self {
+        let (low, high): (&[u8; 16], &[u8; 16]) = (
+            bytes[16..].try_into().unwrap(),
+            bytes[..16].try_into().unwrap(),
+        );
+        Self::from_bytes_be(low, high)
+    }
+}
+
+impl FeltSerialize for CairoU256 {
+    fn to_felts(self) -> Vec<Felt252> {
+        vec![self.low, self.high]
+    }
+}
+
+struct P256r1PublicKey {
+    x: CairoU256,
+    y: CairoU256,
+}
+
+impl P256r1PublicKey {
+    pub fn new(x: CairoU256, y: CairoU256) -> Self {
+        Self { x, y }
+    }
+    pub fn from_bytes_be(x: &[u8; 32], y: &[u8; 32]) -> Self {
+        Self::new(
+            CairoU256::from_byte_slice_be(x),
+            CairoU256::from_byte_slice_be(y),
+        )
+    }
+}
+
+impl FeltSerialize for P256r1PublicKey {
+    fn to_felts(self) -> Vec<Felt252> {
+        self.x
+            .to_felts()
+            .into_iter()
+            .chain(self.y.to_felts())
+            .collect()
+    }
 }
 
 impl ArgsBuilder {

--- a/crates/webauthn/tests/src/auth/mod.rs
+++ b/crates/webauthn/tests/src/auth/mod.rs
@@ -1,5 +1,6 @@
 use cairo_args_runner::{arg_array, arg_value, felt_vec, Arg, Felt252};
 
+mod expand_auth_data;
 mod mod_arithmetic;
 mod verify_ecdsa;
 mod verify_signature;

--- a/crates/webauthn/tests/src/auth/mod.rs
+++ b/crates/webauthn/tests/src/auth/mod.rs
@@ -1,6 +1,7 @@
 use cairo_args_runner::{arg_array, arg_value, felt_vec, Arg, Felt252};
 
 mod expand_auth_data;
+mod helpers;
 mod mod_arithmetic;
 mod verify_ecdsa;
 mod verify_signature;
@@ -10,6 +11,7 @@ pub struct ArgsBuilder {
     args: Vec<Arg>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct CairoU256 {
     low: Felt252,
     high: Felt252,
@@ -28,6 +30,9 @@ impl CairoU256 {
             bytes[..16].try_into().unwrap(),
         );
         Self::from_bytes_be(low, high)
+    }
+    pub fn zero() -> Self {
+        Self::new(Felt252::from(0), Felt252::from(0))
     }
 }
 

--- a/crates/webauthn/tests/src/auth/mod.rs
+++ b/crates/webauthn/tests/src/auth/mod.rs
@@ -1,6 +1,7 @@
 use cairo_args_runner::{arg_array, felt_vec, arg_value};
 
 mod mod_arithmetic;
+mod verify_signature;
 
 #[test]
 fn test_contains_trait() {

--- a/crates/webauthn/tests/src/auth/mod.rs
+++ b/crates/webauthn/tests/src/auth/mod.rs
@@ -1,8 +1,8 @@
 use cairo_args_runner::{arg_array, arg_value, felt_vec, Arg, Felt252};
 
 mod mod_arithmetic;
-mod verify_signature;
 mod verify_ecdsa;
+mod verify_signature;
 
 #[derive(Debug)]
 pub struct ArgsBuilder {
@@ -13,7 +13,6 @@ pub struct CairoU256 {
     low: Felt252,
     high: Felt252,
 }
-
 
 impl CairoU256 {
     pub fn new(low: Felt252, high: Felt252) -> Self {

--- a/crates/webauthn/tests/src/auth/mod.rs
+++ b/crates/webauthn/tests/src/auth/mod.rs
@@ -1,7 +1,39 @@
-use cairo_args_runner::{arg_array, felt_vec, arg_value};
+use cairo_args_runner::{arg_array, arg_value, felt_vec, Arg, Felt252};
 
 mod mod_arithmetic;
 mod verify_signature;
+
+pub struct ArgsBuilder {
+    args: Vec<Arg>,
+}
+
+impl ArgsBuilder {
+    pub fn new() -> Self {
+        Self { args: Vec::new() }
+    }
+    #[allow(dead_code)]
+    pub fn add_one(mut self, arg: impl Into<Felt252>) -> Self {
+        self.args.push(Arg::Value(arg.into()));
+        self
+    }
+    pub fn add_struct(mut self, args: impl IntoIterator<Item = impl Into<Felt252>>) -> Self {
+        self.args
+            .extend(args.into_iter().map(|arg| Arg::Value(arg.into())));
+        self
+    }
+    pub fn add_array(mut self, args: impl IntoIterator<Item = impl Into<Felt252>>) -> Self {
+        self.args
+            .push(Arg::Array(args.into_iter().map(|arg| arg.into()).collect()));
+        self
+    }
+    pub fn build(self) -> Vec<Arg> {
+        self.args
+    }
+}
+
+pub trait FeltSerialize {
+    fn to_felts(self) -> Vec<Felt252>;
+}
 
 #[test]
 fn test_contains_trait() {
@@ -12,7 +44,7 @@ fn test_contains_trait() {
         arg_value!(2),
     ];
     let result = cairo_args_runner::run(target, function, &args).unwrap();
-    
+
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], true.into());
 }

--- a/crates/webauthn/tests/src/auth/mod.rs
+++ b/crates/webauthn/tests/src/auth/mod.rs
@@ -1,4 +1,7 @@
 use cairo_args_runner::{arg_array, felt_vec, arg_value};
+
+mod mod_arithmetic;
+
 #[test]
 fn test_contains_trait() {
     let target = "../../../target/dev/webauthn_auth.sierra.json";

--- a/crates/webauthn/tests/src/auth/mod_arithmetic.rs
+++ b/crates/webauthn/tests/src/auth/mod_arithmetic.rs
@@ -1,0 +1,24 @@
+use cairo_args_runner::felt_vec;
+
+use crate::{FunctionReturnLength, Function, FunctionTrait};
+
+/// ```extended_gcd(u256, u256) -> (u256, u256, u256)```
+const EXTENDED_GCD: FunctionReturnLength<6> = Function::new("extended_gcd");
+
+#[test]
+fn test_gcd_basic_1(){
+    let [gcd, ..] = EXTENDED_GCD.run(felt_vec!(2, 0, 2, 0));
+    assert_eq!(gcd, 2.into());
+}
+
+#[test]
+fn test_gcd_basic_2(){
+    let [gcd, ..] = EXTENDED_GCD.run(felt_vec!(100, 0, 200, 0));
+    assert_eq!(gcd, 100.into());
+}
+
+#[test]
+fn test_gcd_basic_3(){
+    let [gcd, ..] = EXTENDED_GCD.run(felt_vec!(1234, 0, 5678, 0));
+    assert_eq!(gcd, 2.into());
+}

--- a/crates/webauthn/tests/src/auth/mod_arithmetic.rs
+++ b/crates/webauthn/tests/src/auth/mod_arithmetic.rs
@@ -1,4 +1,4 @@
-use cairo_args_runner::felt_vec;
+use cairo_args_runner::{felt_vec, Felt252};
 
 use crate::{Function, FunctionReturnLength, FunctionTrait};
 
@@ -7,18 +7,18 @@ const EXTENDED_GCD: FunctionReturnLength<6> = Function::new("extended_gcd");
 
 #[test]
 fn test_gcd_basic_1() {
-    let [gcd, ..] = EXTENDED_GCD.run(felt_vec!(2, 0, 2, 0));
+    let [gcd, ..]: [Felt252; 6] = EXTENDED_GCD.run(felt_vec!(2, 0, 2, 0));
     assert_eq!(gcd, 2.into());
 }
 
 #[test]
 fn test_gcd_basic_2() {
-    let [gcd, ..] = EXTENDED_GCD.run(felt_vec!(100, 0, 200, 0));
+    let [gcd, ..]: [Felt252; 6] = EXTENDED_GCD.run(felt_vec!(100, 0, 200, 0));
     assert_eq!(gcd, 100.into());
 }
 
 #[test]
 fn test_gcd_basic_3() {
-    let [gcd, ..] = EXTENDED_GCD.run(felt_vec!(1234, 0, 5678, 0));
+    let [gcd, ..]: [Felt252; 6] = EXTENDED_GCD.run(felt_vec!(1234, 0, 5678, 0));
     assert_eq!(gcd, 2.into());
 }

--- a/crates/webauthn/tests/src/auth/mod_arithmetic.rs
+++ b/crates/webauthn/tests/src/auth/mod_arithmetic.rs
@@ -1,24 +1,24 @@
 use cairo_args_runner::felt_vec;
 
-use crate::{FunctionReturnLength, Function, FunctionTrait};
+use crate::{Function, FunctionReturnLength, FunctionTrait};
 
 /// ```extended_gcd(u256, u256) -> (u256, u256, u256)```
 const EXTENDED_GCD: FunctionReturnLength<6> = Function::new("extended_gcd");
 
 #[test]
-fn test_gcd_basic_1(){
+fn test_gcd_basic_1() {
     let [gcd, ..] = EXTENDED_GCD.run(felt_vec!(2, 0, 2, 0));
     assert_eq!(gcd, 2.into());
 }
 
 #[test]
-fn test_gcd_basic_2(){
+fn test_gcd_basic_2() {
     let [gcd, ..] = EXTENDED_GCD.run(felt_vec!(100, 0, 200, 0));
     assert_eq!(gcd, 100.into());
 }
 
 #[test]
-fn test_gcd_basic_3(){
+fn test_gcd_basic_3() {
     let [gcd, ..] = EXTENDED_GCD.run(felt_vec!(1234, 0, 5678, 0));
     assert_eq!(gcd, 2.into());
 }

--- a/crates/webauthn/tests/src/auth/verify_ecdsa.rs
+++ b/crates/webauthn/tests/src/auth/verify_ecdsa.rs
@@ -1,4 +1,5 @@
 use account_sdk::webauthn_signer::P256VerifyingKeyConverter;
+use cairo_args_runner::Felt252;
 use p256::{
     ecdsa::{signature::Signer, Signature, SigningKey},
     elliptic_curve::rand_core::OsRng,
@@ -31,12 +32,12 @@ fn verify_ecdsa(message: &[u8], signing_key: SigningKey, signature: Signature) -
         .add_struct(hash.to_felts())
         .add_struct(r.to_felts())
         .add_struct(s.to_felts());
-    let result = VERIFY_HASHED_ECDSA.run(args.build());
+    let result: [Felt252; 2] = VERIFY_HASHED_ECDSA.run(args.build());
     result == [0.into(), 0.into()]
 }
 
 #[test]
-fn verify_ecdsa_1() {
+fn test_verify_ecdsa_1() {
     let message: &[u8] = b"hello world";
     let signing_key = SigningKey::random(&mut OsRng);
     let (signature, _) = signing_key.sign(message);

--- a/crates/webauthn/tests/src/auth/verify_ecdsa.rs
+++ b/crates/webauthn/tests/src/auth/verify_ecdsa.rs
@@ -1,0 +1,44 @@
+use account_sdk::webauthn_signer::P256VerifyingKeyConverter;
+use p256::{
+    ecdsa::{signature::Signer, Signature, SigningKey},
+    elliptic_curve::rand_core::OsRng,
+};
+
+use crate::{Function, FunctionReturnLength, FunctionTrait};
+
+use super::{ArgsBuilder, CairoU256, FeltSerialize, P256r1PublicKey};
+use sha2::{digest::Update, Digest, Sha256};
+
+const VERIFY_HASHED_ECDSA: FunctionReturnLength<2> = Function::new("verify_hashed_ecdsa_endpoint");
+
+fn verify_ecdsa(message: &[u8], signing_key: SigningKey, signature: Signature) -> bool {
+    let (r, s) = (signature.r(), signature.s());
+    let (r, s) = (r.to_bytes(), s.to_bytes());
+    let (r, s) = (r.as_slice(), s.as_slice());
+    let (r, s) = (
+        CairoU256::from_byte_slice_be(r.try_into().unwrap()),
+        CairoU256::from_byte_slice_be(s.try_into().unwrap()),
+    );
+    let (x, y) = P256VerifyingKeyConverter::new(*signing_key.verifying_key()).to_bytes();
+    let pub_key = P256r1PublicKey::from_bytes_be(&x, &y);
+
+    let hash = Sha256::new().chain(message).finalize();
+    let hash: &[u8] = hash.as_slice();
+    let hash = CairoU256::from_byte_slice_be(hash.try_into().unwrap());
+
+    let args = ArgsBuilder::new()
+        .add_struct(pub_key.to_felts())
+        .add_struct(hash.to_felts())
+        .add_struct(r.to_felts())
+        .add_struct(s.to_felts());
+    let result = VERIFY_HASHED_ECDSA.run(args.build());
+    result == [0.into(), 0.into()]
+}
+
+#[test]
+fn verify_ecdsa_1() {
+    let message: &[u8] = b"hello world";
+    let signing_key = SigningKey::random(&mut OsRng);
+    let (signature, _) = signing_key.sign(message);
+    assert!(verify_ecdsa(message, signing_key, signature));
+}

--- a/crates/webauthn/tests/src/auth/verify_signature.rs
+++ b/crates/webauthn/tests/src/auth/verify_signature.rs
@@ -1,0 +1,40 @@
+use account_sdk::webauthn_signer::P256r1Signer;
+use cairo_args_runner::Felt252;
+use p256::{
+    ecdsa::{signature::Signer, SigningKey},
+    elliptic_curve::{consts::P256, rand_core::OsRng},
+};
+
+use crate::{Function, FunctionUnspecified};
+
+const VERIFY_SIGNATURE: FunctionUnspecified = Function::new_unspecified("verify_signature");
+
+pub struct CairoU256 {
+    low: Felt252,
+    high: Felt252,
+}
+
+impl CairoU256 {
+    pub fn new(low: Felt252, high: Felt252) -> Self {
+        Self { low, high }
+    }
+    pub fn from_bytes_be(low: &[u8; 16], high: &[u8; 16]) -> Self {
+        Self::new(Felt252::from_bytes_be(low), Felt252::from_bytes_be(high))
+    }
+    pub fn from_byte_slice_be(bytes: &[u8]) -> Self {
+        let (low, high): (&[u8; 16], &[u8; 16]) =
+            (bytes[16..].try_into().unwrap(), bytes[..16].try_into().unwrap());
+        Self::from_bytes_be(low, high)
+    }
+}
+
+#[test]
+fn test_verify_signature() {
+    let message = b"hello world";
+    let signing_key = SigningKey::random(&mut OsRng);
+    let (signature, _): (_, _) = signing_key.sign(message);
+    let (r, s) = (signature.r(), signature.s());
+    let (r, s) = (r.to_bytes(), s.to_bytes());
+    let (r, s) = (r.as_slice(), s.as_slice());
+    let p = signing_key.verifying_key().to_sec1_bytes();
+}

--- a/crates/webauthn/tests/src/auth/verify_signature.rs
+++ b/crates/webauthn/tests/src/auth/verify_signature.rs
@@ -115,3 +115,16 @@ fn test_verify_signature_should_fail_1() {
         false
     )
 }
+
+#[test]
+fn test_verify_signature_should_fail_2() {
+    let hash: &[u8] = b"1234567890987654321";
+    let auth_data = b"dummy auth data";
+    let signing_key = SigningKey::random(&mut OsRng);
+    let other_signing_key = SigningKey::random(&mut OsRng);
+    let (signature, _) = signing_key.sign(&vec![auth_data, hash].concat());
+    assert_eq!(
+        verify_signature(hash, auth_data, other_signing_key, signature),
+        false
+    )
+}

--- a/crates/webauthn/tests/src/auth/verify_signature.rs
+++ b/crates/webauthn/tests/src/auth/verify_signature.rs
@@ -1,5 +1,4 @@
 use account_sdk::webauthn_signer::P256VerifyingKeyConverter;
-use cairo_args_runner::Felt252;
 use p256::{
     ecdsa::{signature::Signer, Signature, SigningKey},
     elliptic_curve::rand_core::OsRng,
@@ -7,63 +6,9 @@ use p256::{
 
 use crate::{Function, FunctionTrait as _, FunctionUnspecified};
 
-use super::{ArgsBuilder, FeltSerialize};
+use super::{ArgsBuilder, FeltSerialize, P256r1PublicKey};
 
 const VERIFY_SIGNATURE: FunctionUnspecified = Function::new_unspecified("verify_signature");
-
-pub struct CairoU256 {
-    low: Felt252,
-    high: Felt252,
-}
-
-impl CairoU256 {
-    pub fn new(low: Felt252, high: Felt252) -> Self {
-        Self { low, high }
-    }
-    pub fn from_bytes_be(low: &[u8; 16], high: &[u8; 16]) -> Self {
-        Self::new(Felt252::from_bytes_be(low), Felt252::from_bytes_be(high))
-    }
-    pub fn from_byte_slice_be(bytes: &[u8; 32]) -> Self {
-        let (low, high): (&[u8; 16], &[u8; 16]) = (
-            bytes[16..].try_into().unwrap(),
-            bytes[..16].try_into().unwrap(),
-        );
-        Self::from_bytes_be(low, high)
-    }
-}
-
-impl FeltSerialize for CairoU256 {
-    fn to_felts(self) -> Vec<Felt252> {
-        vec![self.low, self.high]
-    }
-}
-
-struct P256r1PublicKey {
-    x: CairoU256,
-    y: CairoU256,
-}
-
-impl P256r1PublicKey {
-    pub fn new(x: CairoU256, y: CairoU256) -> Self {
-        Self { x, y }
-    }
-    pub fn from_bytes_be(x: &[u8; 32], y: &[u8; 32]) -> Self {
-        Self::new(
-            CairoU256::from_byte_slice_be(x),
-            CairoU256::from_byte_slice_be(y),
-        )
-    }
-}
-
-impl FeltSerialize for P256r1PublicKey {
-    fn to_felts(self) -> Vec<Felt252> {
-        self.x
-            .to_felts()
-            .into_iter()
-            .chain(self.y.to_felts())
-            .collect()
-    }
-}
 
 fn verify_signature(
     hash: &[u8],

--- a/crates/webauthn/tests/src/auth/verify_signature.rs
+++ b/crates/webauthn/tests/src/auth/verify_signature.rs
@@ -1,11 +1,13 @@
-use account_sdk::webauthn_signer::P256r1Signer;
+use account_sdk::webauthn_signer::P256VerifyingKeyConverter;
 use cairo_args_runner::Felt252;
 use p256::{
-    ecdsa::{signature::Signer, SigningKey},
-    elliptic_curve::{consts::P256, rand_core::OsRng},
+    ecdsa::{signature::Signer, Signature, SigningKey},
+    elliptic_curve::rand_core::OsRng,
 };
 
-use crate::{Function, FunctionUnspecified};
+use crate::{Function, FunctionTrait as _, FunctionUnspecified};
+
+use super::{ArgsBuilder, FeltSerialize};
 
 const VERIFY_SIGNATURE: FunctionUnspecified = Function::new_unspecified("verify_signature");
 
@@ -21,20 +23,95 @@ impl CairoU256 {
     pub fn from_bytes_be(low: &[u8; 16], high: &[u8; 16]) -> Self {
         Self::new(Felt252::from_bytes_be(low), Felt252::from_bytes_be(high))
     }
-    pub fn from_byte_slice_be(bytes: &[u8]) -> Self {
-        let (low, high): (&[u8; 16], &[u8; 16]) =
-            (bytes[16..].try_into().unwrap(), bytes[..16].try_into().unwrap());
+    pub fn from_byte_slice_be(bytes: &[u8; 32]) -> Self {
+        let (low, high): (&[u8; 16], &[u8; 16]) = (
+            bytes[16..].try_into().unwrap(),
+            bytes[..16].try_into().unwrap(),
+        );
         Self::from_bytes_be(low, high)
     }
 }
 
-#[test]
-fn test_verify_signature() {
-    let message = b"hello world";
-    let signing_key = SigningKey::random(&mut OsRng);
-    let (signature, _): (_, _) = signing_key.sign(message);
+impl FeltSerialize for CairoU256 {
+    fn to_felts(self) -> Vec<Felt252> {
+        vec![self.low, self.high]
+    }
+}
+
+struct P256r1PublicKey {
+    x: CairoU256,
+    y: CairoU256,
+}
+
+impl P256r1PublicKey {
+    pub fn new(x: CairoU256, y: CairoU256) -> Self {
+        Self { x, y }
+    }
+    pub fn from_bytes_be(x: &[u8; 32], y: &[u8; 32]) -> Self {
+        Self::new(
+            CairoU256::from_byte_slice_be(x),
+            CairoU256::from_byte_slice_be(y),
+        )
+    }
+}
+
+impl FeltSerialize for P256r1PublicKey {
+    fn to_felts(self) -> Vec<Felt252> {
+        self.x
+            .to_felts()
+            .into_iter()
+            .chain(self.y.to_felts())
+            .collect()
+    }
+}
+
+fn verify_signature(
+    hash: &[u8],
+    auth_data: &[u8],
+    signing_key: SigningKey,
+    signature: Signature,
+) -> bool {
     let (r, s) = (signature.r(), signature.s());
     let (r, s) = (r.to_bytes(), s.to_bytes());
     let (r, s) = (r.as_slice(), s.as_slice());
-    let p = signing_key.verifying_key().to_sec1_bytes();
+    let (x, y) = P256VerifyingKeyConverter::new(*signing_key.verifying_key()).to_bytes();
+    let pub_key = P256r1PublicKey::from_bytes_be(&x, &y);
+    let args = ArgsBuilder::new()
+        .add_array(hash.iter().cloned())
+        .add_array(auth_data.iter().cloned())
+        .add_struct(pub_key.to_felts())
+        .add_array(r.into_iter().copied().chain(s.iter().copied()));
+    let result = VERIFY_SIGNATURE.run(args.build());
+    result == vec![0.into(), 0.into()]
+}
+
+#[test]
+fn test_verify_signature_1() {
+    let hash: &[u8] = b"hello world";
+    let auth_data = b"dummy auth data";
+    let signing_key = SigningKey::random(&mut OsRng);
+    let (signature, _) = signing_key.sign(&vec![auth_data, hash].concat());
+    assert!(verify_signature(hash, auth_data, signing_key, signature))
+}
+
+#[test]
+fn test_verify_signature_2() {
+    let hash: &[u8] = b"1234567890987654321";
+    let auth_data = b"auuuuuuuuuuth daaaaataaaaaaaaaa";
+    let signing_key = SigningKey::random(&mut OsRng);
+    let (signature, _) = signing_key.sign(&vec![auth_data, hash].concat());
+    assert!(verify_signature(hash, auth_data, signing_key, signature))
+}
+
+#[test]
+fn test_verify_signature_should_fail_1() {
+    let hash = b"hello world";
+    let auth_data = b"dummy auth data";
+    let wrong_hash: &[u8] = b"definetly not hello world";
+    let signing_key = SigningKey::random(&mut OsRng);
+    let (signature, _) = signing_key.sign(&vec![auth_data, wrong_hash].concat());
+    assert_eq!(
+        verify_signature(hash, auth_data, signing_key, signature),
+        false
+    )
 }

--- a/crates/webauthn/tests/src/auth/verify_signature.rs
+++ b/crates/webauthn/tests/src/auth/verify_signature.rs
@@ -1,4 +1,5 @@
 use account_sdk::webauthn_signer::P256VerifyingKeyConverter;
+use cairo_args_runner::Felt252;
 use p256::{
     ecdsa::{signature::Signer, Signature, SigningKey},
     elliptic_curve::rand_core::OsRng,
@@ -26,7 +27,7 @@ fn verify_signature(
         .add_array(auth_data.iter().cloned())
         .add_struct(pub_key.to_felts())
         .add_array(r.into_iter().copied().chain(s.iter().copied()));
-    let result = VERIFY_SIGNATURE.run(args.build());
+    let result: [Felt252; 2] = VERIFY_SIGNATURE.run(args.build());
     result == [0.into(), 0.into()]
 }
 

--- a/crates/webauthn/tests/src/auth/verify_signature.rs
+++ b/crates/webauthn/tests/src/auth/verify_signature.rs
@@ -4,11 +4,11 @@ use p256::{
     elliptic_curve::rand_core::OsRng,
 };
 
-use crate::{Function, FunctionTrait as _, FunctionUnspecified};
+use crate::{Function, FunctionReturnLength, FunctionTrait as _};
 
 use super::{ArgsBuilder, FeltSerialize, P256r1PublicKey};
 
-const VERIFY_SIGNATURE: FunctionUnspecified = Function::new_unspecified("verify_signature");
+const VERIFY_SIGNATURE: FunctionReturnLength<2> = Function::new("verify_signature");
 
 fn verify_signature(
     hash: &[u8],
@@ -27,7 +27,7 @@ fn verify_signature(
         .add_struct(pub_key.to_felts())
         .add_array(r.into_iter().copied().chain(s.iter().copied()));
     let result = VERIFY_SIGNATURE.run(args.build());
-    result == vec![0.into(), 0.into()]
+    result == [0.into(), 0.into()]
 }
 
 #[test]

--- a/crates/webauthn/tests/src/helpers.rs
+++ b/crates/webauthn/tests/src/helpers.rs
@@ -1,3 +1,5 @@
+use cairo_args_runner::errors::SierraRunnerError;
+use cairo_args_runner::SuccessfulRun;
 use cairo_args_runner::{Arg, Felt252};
 
 pub const SIERRA_TARGET: &'static str = "../../../target/dev/webauthn_auth.sierra.json";
@@ -23,39 +25,79 @@ impl Function {
     }
 }
 
-pub trait FunctionTrait<T, P>
-where
-    T: Into<Vec<Felt252>>,
-{
-    fn run(&self, args: Vec<P>) -> T;
+pub trait FunctionTrait<T, P> {
+    fn run(&self, args: P) -> T {
+        self.transform_result(cairo_args_runner::run_capture_memory(
+            SIERRA_TARGET,
+            self.name(),
+            &self.transform_arguments(args),
+        ))
+    }
+    fn transform_arguments(&self, args: P) -> Vec<Arg>;
+    fn transform_result(&self, result: Result<SuccessfulRun, SierraRunnerError>) -> T;
+    fn name(&self) -> &str;
 }
 
-impl<'a, const N: usize, P> FunctionTrait<[Felt252; N], P> for FunctionReturnLength<'a, N>
+impl<'a, const N: usize, P> FunctionTrait<[Felt252; N], Vec<P>> for FunctionReturnLength<'a, N>
 where
     P: Into<Arg>,
 {
-    fn run(&self, args: Vec<P>) -> [Felt252; N] {
-        cairo_args_runner::run(
-            SIERRA_TARGET,
-            &self.name,
-            &args.into_iter().map(Into::into).collect::<Vec<_>>(),
-        )
-        .unwrap()
-        .try_into()
-        .unwrap()
+    fn transform_arguments(&self, args: Vec<P>) -> Vec<Arg> {
+        args.into_iter().map(Into::into).collect()
+    }
+
+    fn transform_result(&self, result: Result<SuccessfulRun, SierraRunnerError>) -> [Felt252; N] {
+        result.unwrap().value.try_into().unwrap()
+    }
+
+    fn name(&self) -> &str {
+        self.name
     }
 }
 
-impl<'a, P> FunctionTrait<Vec<Felt252>, P> for FunctionUnspecified<'a>
+pub struct SpecifiedWithMemory<const N: usize> {
+    result: [Felt252; N],
+    memory: Vec<Option<Felt252>>,
+}
+
+impl<'a, const N: usize, P> FunctionTrait<SpecifiedWithMemory<N>, Vec<P>>
+    for FunctionReturnLength<'a, N>
 where
     P: Into<Arg>,
 {
-    fn run(&self, args: Vec<P>) -> Vec<Felt252> {
-        cairo_args_runner::run(
-            SIERRA_TARGET,
-            &self.name,
-            &args.into_iter().map(Into::into).collect::<Vec<_>>(),
-        )
-        .unwrap()
+    fn transform_arguments(&self, args: Vec<P>) -> Vec<Arg> {
+        args.into_iter().map(Into::into).collect()
+    }
+
+    fn transform_result(
+        &self,
+        result: Result<SuccessfulRun, SierraRunnerError>,
+    ) -> SpecifiedWithMemory<N> {
+        let r = result.unwrap();
+        SpecifiedWithMemory {
+            result: r.value.try_into().unwrap(),
+            memory: r.memory,
+        }
+    }
+
+    fn name(&self) -> &str {
+        self.name
+    }
+}
+
+impl<'a, P> FunctionTrait<Vec<Felt252>, Vec<P>> for FunctionUnspecified<'a>
+where
+    P: Into<Arg>,
+{
+    fn transform_arguments(&self, args: Vec<P>) -> Vec<Arg> {
+        args.into_iter().map(Into::into).collect()
+    }
+
+    fn transform_result(&self, result: Result<SuccessfulRun, SierraRunnerError>) -> Vec<Felt252> {
+        result.unwrap().value
+    }
+
+    fn name(&self) -> &str {
+        self.name
     }
 }

--- a/crates/webauthn/tests/src/helpers.rs
+++ b/crates/webauthn/tests/src/helpers.rs
@@ -38,6 +38,12 @@ pub trait FunctionTrait<T, P> {
     fn name(&self) -> &str;
 }
 
+#[derive(Debug, PartialEq)]
+pub struct SpecifiedResultMemory<T> {
+    result: T,
+    memory: Vec<Option<Felt252>>,
+}
+
 impl<'a, const N: usize, P> FunctionTrait<[Felt252; N], Vec<P>> for FunctionReturnLength<'a, N>
 where
     P: Into<Arg>,
@@ -48,36 +54,6 @@ where
 
     fn transform_result(&self, result: Result<SuccessfulRun, SierraRunnerError>) -> [Felt252; N] {
         result.unwrap().value.try_into().unwrap()
-    }
-
-    fn name(&self) -> &str {
-        self.name
-    }
-}
-
-pub struct SpecifiedWithMemory<const N: usize> {
-    result: [Felt252; N],
-    memory: Vec<Option<Felt252>>,
-}
-
-impl<'a, const N: usize, P> FunctionTrait<SpecifiedWithMemory<N>, Vec<P>>
-    for FunctionReturnLength<'a, N>
-where
-    P: Into<Arg>,
-{
-    fn transform_arguments(&self, args: Vec<P>) -> Vec<Arg> {
-        args.into_iter().map(Into::into).collect()
-    }
-
-    fn transform_result(
-        &self,
-        result: Result<SuccessfulRun, SierraRunnerError>,
-    ) -> SpecifiedWithMemory<N> {
-        let r = result.unwrap();
-        SpecifiedWithMemory {
-            result: r.value.try_into().unwrap(),
-            memory: r.memory,
-        }
     }
 
     fn name(&self) -> &str {

--- a/crates/webauthn/tests/src/helpers.rs
+++ b/crates/webauthn/tests/src/helpers.rs
@@ -1,0 +1,61 @@
+use cairo_args_runner::{Arg, Felt252};
+
+pub const SIERRA_TARGET: &'static str = "../../../target/dev/webauthn_auth.sierra.json";
+
+#[derive(Debug, Clone, Copy)]
+pub struct FunctionReturnLength<'a, const N: usize> {
+    pub name: &'a str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FunctionUnspecified<'a> {
+    pub name: &'a str,
+}
+
+pub enum Function {}
+
+impl Function {
+    pub const fn new<'a, const N: usize>(name: &'a str) -> FunctionReturnLength<'a, N> {
+        FunctionReturnLength { name }
+    }
+    pub const fn new_unspecified<'a>(name: &'a str) -> FunctionUnspecified<'a> {
+        FunctionUnspecified { name }
+    }
+}
+
+pub trait FunctionTrait<T, P>
+where
+    T: Into<Vec<Felt252>>,
+{
+    fn run(&self, args: Vec<P>) -> T;
+}
+
+impl<'a, const N: usize, P> FunctionTrait<[Felt252; N], P> for FunctionReturnLength<'a, N>
+where
+    P: Into<Arg>,
+{
+    fn run(&self, args: Vec<P>) -> [Felt252; N] {
+        cairo_args_runner::run(
+            SIERRA_TARGET,
+            &self.name,
+            &args.into_iter().map(Into::into).collect::<Vec<_>>(),
+        )
+        .unwrap()
+        .try_into()
+        .unwrap()
+    }
+}
+
+impl<'a, P> FunctionTrait<Vec<Felt252>, P> for FunctionUnspecified<'a>
+where
+    P: Into<Arg>,
+{
+    fn run(&self, args: Vec<P>) -> Vec<Felt252> {
+        cairo_args_runner::run(
+            SIERRA_TARGET,
+            &self.name,
+            &args.into_iter().map(Into::into).collect::<Vec<_>>(),
+        )
+        .unwrap()
+    }
+}

--- a/crates/webauthn/tests/src/lib.rs
+++ b/crates/webauthn/tests/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
-mod webauthn;
+mod auth;
 
-
-
-
+#[cfg(test)]
+mod helpers;
+#[cfg(test)]
+pub use helpers::*;


### PR DESCRIPTION
In this PR I've moved the python generated tests of the webauthn_auth crate to rust, using cairo_args_runner. I've also added some missing functionality to the cairo_args_runner (outside of this repo) like capturing the memory. This was required to extract values from the returned arrays (which are encoded as fat pointers). 
